### PR TITLE
Add mail config variables, remove unused configuration variables

### DIFF
--- a/_SQL/zmeny.sql.php
+++ b/_SQL/zmeny.sql.php
@@ -23,6 +23,7 @@ AddZmenyFile('3.3.0.590');
 AddZmenyFile('3.4.0.600');
 AddZmenyFile('3.4.1.631');
 AddZmenyFile('3.4.1.646');
+AddZmenyFile('3.4.1.647');
 //#############################################################################
 
 require_once ('connect.inc.php');

--- a/_SQL/zmeny_3.4.1.647.sql.php
+++ b/_SQL/zmeny_3.4.1.647.sql.php
@@ -1,0 +1,29 @@
+<?
+
+//#############################################################################
+//	vychozi verze
+//#############################################################################
+
+$version_upd = '3.4.1.647';
+
+//#############################################################################
+
+require_once ('prepare.inc.php');
+
+//#############################################################################
+//	SQL dotazy pro zmenu db. na novejsi verzi
+//#############################################################################
+
+# *** pridani sloupcu pro notifikace
+$sql[1] = "CREATE TABLE `" . TBL_TOKENS . "` (
+ `device` varchar(36) NOT NULL COMMENT 'https://capacitorjs.com/docs/apis/device#deviceid',
+ `user_id` smallint(5) NOT NULL,
+ `fcm_token` varchar(4096) NOT NULL,
+ `fcm_token_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'update on token update',
+ PRIMARY KEY (`device`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_czech_ci";
+
+//#############################################################################
+
+require_once ('action.inc.php');
+?>

--- a/cfg/_cfg.php.default
+++ b/cfg/_cfg.php.default
@@ -26,16 +26,13 @@ $g_dbpass='root';
 $g_dbname='members';
 
 //==================================================================
-// jwt secret key
-//==================================================================
-// head -c 64 /dev/urandom | base64
-$g_jwt_secret_key = "DEVELOPMENT+ONLY+++GENERATE+A+SECURE+64+BYTE+KEY+IN+PRODUCTION++/uV4zp8UPeLiSXUL62Ae/w=="; // ### TREBA ZMENIT ###
-
-//==================================================================
 // api
 //==================================================================
-// api version
-$g_api_version = 2.12;
+// allows sending notification for this club
+$g_enable_notify = true;
+// a secret key used for signing jwt tokens
+// head -c 64 /dev/urandom | base64
+$g_jwt_secret_key = "DEVELOPMENT+ONLY+++GENERATE+A+SECURE+64+BYTE+KEY+IN+PRODUCTION++/uV4zp8UPeLiSXUL62Ae/w==";
 
 //==================================================================
 // http server
@@ -55,12 +52,26 @@ $g_baseadr='http://localhost/members/';
 // adresa hlavnich stranek oddilu
 $g_mainwww='http://localhost/';
 
-// e-mailove adresy
-$g_emailadr='email@eob.cz';
 // Logovat informace o neuspesnem prihlaseni
 $g_log_loginfailed=true;
 
 $g_is_release = true;
+
+//==================================================================
+// mail server
+//==================================================================
+// e-mailove adresa pre uzivatelov
+$g_emailadr='email@eob.cz';
+// adresa, kam a odkial posielat informacie z cron
+$g_mail_reply_to = "web@eob.cz";
+$g_mail_from = "web@eob.cz";
+// prihlasovacie udaje na mailovy server
+$g_mail_smtp_host = "smtp-domena.wedos.net";
+$g_mail_smtp_user = "web@eob.cz";
+$g_mail_smtp_pswd = "smtp-heslo";
+$g_mail_smtp_port = 587;
+$g_mail_smtp_auth = true;
+$g_mail_smtp_secure = "tls";
 
 //==================================================================
 // customization

--- a/cfg/_tables.php.default
+++ b/cfg/_tables.php.default
@@ -21,6 +21,7 @@ define ('TBL_MODLOG','modify_log');
 define ('TBL_MAILINFO','mailinfo');
 define ('TBL_FINANCE','finance');
 define ('TBL_CLAIM','claim');
+define ('TBL_TOKENS','tokens');
 define ('TBL_FINANCE_TYPES','finance_types');
 define ('TBL_CATEGORIES_PREDEF','categories_predef');
 

--- a/version.inc.php
+++ b/version.inc.php
@@ -6,7 +6,7 @@ define('SYSTEM_AUTORS','Arnošt, Kenia, LuF, Jurakin a Svatoš');
 
 function GetCodeVersion()
 {
-	return "v3.4.2.646";
+	return "v3.4.2.647";
 }
 
 function GetCopyright()


### PR DESCRIPTION
Added variables:
- 8 configuration variables needed for global api (prefixed `$g_mail`)
- `$g_enable_notify`
- `TBL_TOKENS`

Removed variables:
- `$g_api_version`
