### PR TITLE
fix(security): protect admin-only scripts from public HTTP access

### DIFF
--- a/_copy_production_tables.php
+++ b/_copy_production_tables.php
@@ -6,6 +6,13 @@
 
 require ('./cfg/_cfg.php');
 
+if (php_sapi_name() !== 'cli') {
+    if (!isset($_GET['secret']) || $_GET['secret'] !== $g_cron_secret) {
+        http_response_code(403);
+        exit('Forbidden');
+    }
+}
+
 //nastavit vsem heslo na '12345' - 1 = True, 0 = False
 $set_default_password=1;
 $default_password=password_hash(md5('12345'), PASSWORD_DEFAULT);

--- a/_cron_.php
+++ b/_cron_.php
@@ -27,6 +27,14 @@ header("Pragma: no-cache");
 
 require_once (dirname(__FILE__) .'/cfg/_globals.php');
 require_once (dirname(__FILE__) .'/connect.inc.php');
+
+if (php_sapi_name() !== 'cli') {
+    if (!isset($_GET['secret']) || $_GET['secret'] !== $g_cron_secret) {
+        http_response_code(403);
+        exit('Forbidden');
+    }
+}
+
 require_once (dirname(__FILE__) .'/common.inc.php');
 require_once (dirname(__FILE__) .'/common_race.inc.php');
 require_once (dirname(__FILE__) .'/common_fin.inc.php');

--- a/_zmeny_ad.php
+++ b/_zmeny_ad.php
@@ -19,6 +19,14 @@ require_once ('timestamp.inc.php');
 _set_global_RT_Start();
 require_once('cfg/_globals.php');
 require_once ('connect.inc.php');
+
+if (php_sapi_name() !== 'cli') {
+    if (!isset($_GET['secret']) || $_GET['secret'] !== $g_cron_secret) {
+        http_response_code(403);
+        exit('Forbidden');
+    }
+}
+
 require_once ('./version.inc.php');
 require_once ('common.inc.php');
 

--- a/cfg/_cfg.php.default
+++ b/cfg/_cfg.php.default
@@ -34,6 +34,10 @@ $g_enable_notify = true;
 // head -c 64 /dev/urandom | base64
 $g_jwt_secret_key = "DEVELOPMENT+ONLY+++GENERATE+A+SECURE+64+BYTE+KEY+IN+PRODUCTION++/uV4zp8UPeLiSXUL62Ae/w==";
 
+// secret token to protect cron/admin-only scripts from public HTTP access
+// generate with: openssl rand -hex 32
+$g_cron_secret = 'CHANGE_ME_TO_A_RANDOM_STRING';
+
 //==================================================================
 // http server
 //==================================================================


### PR DESCRIPTION
Add a secret token guard to _cron_.php, _zmeny_ad.php and _copy_production_tables.php. HTTP requests without a matching ?secret=<value> receive a 403. CLI invocations (php_sapi_name() === 'cli') bypass the check so crontab shell execution is unaffected.

The secret is configured via $g_cron_secret in cfg/_cfg.php.

Don't know how it's done in production (CLI/curl), but don't forget to update production env if it's done via curl:

1. Add $g_cron_secret = '<your_random_value>'; to cfg/_cfg.php
2. Update your crontab curl call:
      curl "https://yourdomain/members/_cron_.php?secret=<your_random_value>"
