### PR TITLE
refactor: remove extract() calls and replace with explicit variable assignments

### DIFF
--- a/_SQL/prepare.inc.php
+++ b/_SQL/prepare.inc.php
@@ -1,5 +1,6 @@
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$version_upd = $_REQUEST['version_upd'] ?? null;
+$sql = $_REQUEST['sql'] ?? null;
 $this_file_name = 'zmeny_'.$version_upd.'.sql.php';
 
 require_once ('connect.inc.php');

--- a/_SQL/zmeny.sql.php
+++ b/_SQL/zmeny.sql.php
@@ -1,5 +1,5 @@
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$action = $_REQUEST['action'] ?? null;
 
 $zmeny_list = array();
 function AddZmenyFile($version)

--- a/adm_reset_ft.php
+++ b/adm_reset_ft.php
@@ -1,7 +1,7 @@
 <?php /* adminova stranka - editace clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$accept = $_REQUEST['accept'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/ads_oris_si_sync.php
+++ b/ads_oris_si_sync.php
@@ -1,7 +1,8 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$oris_id = $_REQUEST['oris_id'] ?? null;
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/api/race.php
+++ b/api/race.php
@@ -128,7 +128,12 @@ switch ($action) {
                 raise_and_die("$key is not set");
             }
         }
-        extract($required_data);
+        $category = $required_data['category'];
+        $note = $required_data['note'];
+        $note_internal = $required_data['note_internal'];
+        $transport = $required_data['transport'];
+        $sedadlel = $required_data['sedadlel'];
+        $accommodation = $required_data['accommodation'];
 
         $transport = $transport ? 1 : 0;
         $accommodation = $accommodation ? 1 : 0;

--- a/categ_predef.php
+++ b/categ_predef.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/categ_predef_edit.php
+++ b/categ_predef_edit.php
@@ -1,7 +1,7 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/claim.php
+++ b/claim.php
@@ -1,7 +1,10 @@
 <?php /* zobrazeni reklamace pro platbu */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$payment_id = $_REQUEST['payment_id'] ?? null;
+$submit = $_REQUEST['submit'] ?? null;
+$close = $_REQUEST['close'] ?? null;
+$claim_text = $_REQUEST['claim_text'] ?? null;
 
 $payment_id = (IsSet($payment_id) && is_numeric($payment_id)) ? (int)$payment_id : 0;
 

--- a/error.php
+++ b/error.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$code = $_REQUEST['code'] ?? null;
 
 require_once("./cfg/_cfg.php");
 require_once ("./sess.inc.php");

--- a/export_directory.php
+++ b/export_directory.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+
 
 require_once('./cfg/_colors.php');
 require_once ('./connect.inc.php');

--- a/export_directory_exc.php
+++ b/export_directory_exc.php
@@ -1,6 +1,9 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$par1 = $_REQUEST['par1'] ?? null;
+$par2 = $_REQUEST['par2'] ?? null;
+$par3 = $_REQUEST['par3'] ?? null;
+$oris = $_REQUEST['oris'] ?? null;
 
 require_once ('./connect.inc.php');
 require_once ('./sess.inc.php');

--- a/fin_directory_export_exc.php
+++ b/fin_directory_export_exc.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+
 
 require_once ('./connect.inc.php');
 require_once ('./sess.inc.php');

--- a/fin_payrule_del_exc.php
+++ b/fin_payrule_del_exc.php
@@ -1,5 +1,5 @@
 <?php /* definice plateb - mazani */
-@extract($_REQUEST);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/fin_payrule_edit.php
+++ b/fin_payrule_edit.php
@@ -1,7 +1,7 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST);
+
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/fin_payrule_edit_exc.php
+++ b/fin_payrule_edit_exc.php
@@ -1,6 +1,6 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
-@extract($_REQUEST);
+
 
 require_once ('connect.inc.php');
 require_once ('sess.inc.php');

--- a/fin_type_edit.php
+++ b/fin_type_edit.php
@@ -1,7 +1,7 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/fin_type_edit_exc.php
+++ b/fin_type_edit_exc.php
@@ -1,6 +1,8 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php /* finance - editace (pridavani) typu prispevku */
-@extract($_REQUEST, EXTR_SKIP);
+$nazev = $_REQUEST['nazev'] ?? null;
+$popis = $_REQUEST['popis'] ?? null;
+$update = $_REQUEST['update'] ?? null;
 
 require_once ('connect.inc.php');
 require_once ('sess.inc.php');

--- a/find_reg.php
+++ b/find_reg.php
@@ -1,7 +1,8 @@
 <?php /* adminova stranka - editace clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$reg = $_REQUEST['reg'] ?? null;
+$year = $_REQUEST['year'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+
 
 $id = (IsSet($_GET['id']) && is_numeric($_GET['id'])) ? (int)$_GET['id'] : 0;
 $subid = (IsSet($_GET['subid']) && is_numeric($_GET['subid'])) ? (int)$_GET['subid'] : 0;

--- a/mng_edit.php
+++ b/mng_edit.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once('./cfg/_colors.php');
 require_once ('./connect.inc.php');

--- a/mng_edit_exc.php
+++ b/mng_edit_exc.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$mng = $_REQUEST['mng'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/mng_smng_view.php
+++ b/mng_smng_view.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/mns_user_edit.php
+++ b/mns_user_edit.php
@@ -1,7 +1,9 @@
 <?php /* adminova stranka - editace clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$chiefPayFor = $_REQUEST['chiefPayFor'] ?? null;
+$chief_pay = $_REQUEST['chief_pay'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/mns_user_login_edit.php
+++ b/mns_user_login_edit.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/news_new_exc.php
+++ b/news_new_exc.php
@@ -1,6 +1,10 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php /* novinky - editace (pridavani) novinek */
-@extract($_REQUEST, EXTR_SKIP);
+$datum = $_REQUEST['datum'] ?? null;
+$text = $_REQUEST['text'] ?? null;
+$nadpis = $_REQUEST['nadpis'] ?? null;
+$internal = $_REQUEST['internal'] ?? null;
+$update = $_REQUEST['update'] ?? null;
 
 require_once ('connect.inc.php');
 require_once ('sess.inc.php');

--- a/race_boss.php
+++ b/race_boss.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_boss_exc.php
+++ b/race_boss_exc.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$boss = $_REQUEST['boss'] ?? null;
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_del_exc.php
+++ b/race_del_exc.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_edit.php
+++ b/race_edit.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$ext_id = $_REQUEST['ext_id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_edit_exc.php
+++ b/race_edit_exc.php
@@ -1,6 +1,29 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$rtype = $_REQUEST['rtype'] ?? null;
+$datum = $_REQUEST['datum'] ?? null;
+$datum2 = $_REQUEST['datum2'] ?? null;
+$etap = $_REQUEST['etap'] ?? null;
+$zebricek = $_REQUEST['zebricek'] ?? null;
+$prihlasky1 = $_REQUEST['prihlasky1'] ?? null;
+$prihlasky2 = $_REQUEST['prihlasky2'] ?? null;
+$prihlasky3 = $_REQUEST['prihlasky3'] ?? null;
+$prihlasky4 = $_REQUEST['prihlasky4'] ?? null;
+$prihlasky5 = $_REQUEST['prihlasky5'] ?? null;
+$odkaz = $_REQUEST['odkaz'] ?? null;
+$nazev = $_REQUEST['nazev'] ?? null;
+$ext_id = $_REQUEST['ext_id'] ?? null;
+$misto = $_REQUEST['misto'] ?? null;
+$typ0 = $_REQUEST['typ0'] ?? null;
+$typ = $_REQUEST['typ'] ?? null;
+$ranking = $_REQUEST['ranking'] ?? null;
+$oddil = $_REQUEST['oddil'] ?? null;
+$poznamka = $_REQUEST['poznamka'] ?? null;
+$transport = $_REQUEST['transport'] ?? null;
+$accommodation = $_REQUEST['accommodation'] ?? null;
+$kapacita = $_REQUEST['kapacita'] ?? null;
+$cancelled = $_REQUEST['cancelled'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_finance_view.php
+++ b/race_finance_view.php
@@ -1,7 +1,9 @@
 <?php /* maly trener - zobrazeni detailu financi pro clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$race_id = $_REQUEST['race_id'] ?? null;
+$payment = $_REQUEST['payment'] ?? null;
+$msg = $_REQUEST['msg'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_imports.php
+++ b/race_imports.php
@@ -1,7 +1,8 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$from = $_REQUEST['from'] ?? null;
+$to = $_REQUEST['to'] ?? null;
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/race_info_show.php
+++ b/race_info_show.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
 
 require_once('./cfg/_colors.php');
 require_once ('./connect.inc.php');

--- a/race_kat.php
+++ b/race_kat.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_kat_exc.php
+++ b/race_kat_exc.php
@@ -1,6 +1,9 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$H = $_REQUEST['H'] ?? null;
+$D = $_REQUEST['D'] ?? null;
+$kat_n = $_REQUEST['kat_n'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_new.php
+++ b/race_new.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$ext_id = $_REQUEST['ext_id'] ?? null;
+$type = $_REQUEST['type'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_new_exc.php
+++ b/race_new_exc.php
@@ -1,6 +1,28 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$rtype = $_REQUEST['rtype'] ?? null;
+$datum = $_REQUEST['datum'] ?? null;
+$datum2 = $_REQUEST['datum2'] ?? null;
+$etap = $_REQUEST['etap'] ?? null;
+$zebricek = $_REQUEST['zebricek'] ?? null;
+$prihlasky1 = $_REQUEST['prihlasky1'] ?? null;
+$prihlasky2 = $_REQUEST['prihlasky2'] ?? null;
+$prihlasky3 = $_REQUEST['prihlasky3'] ?? null;
+$prihlasky4 = $_REQUEST['prihlasky4'] ?? null;
+$prihlasky5 = $_REQUEST['prihlasky5'] ?? null;
+$odkaz = $_REQUEST['odkaz'] ?? null;
+$nazev = $_REQUEST['nazev'] ?? null;
+$ext_id = $_REQUEST['ext_id'] ?? null;
+$misto = $_REQUEST['misto'] ?? null;
+$typ0 = $_REQUEST['typ0'] ?? null;
+$typ = $_REQUEST['typ'] ?? null;
+$ranking = $_REQUEST['ranking'] ?? null;
+$oddil = $_REQUEST['oddil'] ?? null;
+$kategorie = $_REQUEST['kategorie'] ?? null;
+$poznamka = $_REQUEST['poznamka'] ?? null;
+$transport = $_REQUEST['transport'] ?? null;
+$accommodation = $_REQUEST['accommodation'] ?? null;
+$kapacita = $_REQUEST['kapacita'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_reg_chip.php
+++ b/race_reg_chip.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/race_reg_chip_exc.php
+++ b/race_reg_chip_exc.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
+$chip = $_REQUEST['chip'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/race_reg_form.php
+++ b/race_reg_form.php
@@ -1,6 +1,8 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
+$regsend = $_REQUEST['regsend'] ?? null;
+$regsendnow = $_REQUEST['regsendnow'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/race_reg_form_all.php
+++ b/race_reg_form_all.php
@@ -1,6 +1,10 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$gen = $_REQUEST['gen'] ?? null;
+$rt = $_REQUEST['rt'] ?? null;
+$kateg = $_REQUEST['kateg'] ?? null;
+$pozn = $_REQUEST['pozn'] ?? null;
+$chip = $_REQUEST['chip'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once("./cfg/_globals.php");

--- a/race_reg_form_exc.php
+++ b/race_reg_form_exc.php
@@ -1,6 +1,9 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
+$termin = $_REQUEST['termin'] ?? null;
+$ff = $_REQUEST['ff'] ?? null;
+$creg = $_REQUEST['creg'] ?? null;
 
 require_once ('./connect.inc.php');
 require_once ('./sess.inc.php');

--- a/race_reg_view.php
+++ b/race_reg_view.php
@@ -1,6 +1,9 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$us = $_REQUEST['us'] ?? null;
+$gr_id = $_REQUEST['gr_id'] ?? null;
+$select = $_REQUEST['select'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/race_regs_1.php
+++ b/race_regs_1.php
@@ -1,6 +1,8 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$gr_id = $_REQUEST['gr_id'] ?? null;
+$id = $_REQUEST['id'] ?? null;
+$show_ed = $_REQUEST['show_ed'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/race_regs_1_exc.php
+++ b/race_regs_1_exc.php
@@ -1,6 +1,16 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$gr_id = $_REQUEST['gr_id'] ?? null;
+$id = $_REQUEST['id'] ?? null;
+$show_ed = $_REQUEST['show_ed'] ?? null;
+$user_id = $_REQUEST['user_id'] ?? null;
+$kateg = $_REQUEST['kateg'] ?? null;
+$pozn = $_REQUEST['pozn'] ?? null;
+$pozn2 = $_REQUEST['pozn2'] ?? null;
+$new_termin = $_REQUEST['new_termin'] ?? null;
+$transport = $_REQUEST['transport'] ?? null;
+$sedadel = $_REQUEST['sedadel'] ?? null;
+$ubytovani = $_REQUEST['ubytovani'] ?? null;
 
 //TBD: podpora entry_locked
 

--- a/race_regs_all.php
+++ b/race_regs_all.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$gr_id = $_REQUEST['gr_id'] ?? null;
+$id = $_REQUEST['id'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once("./cfg/_globals.php");

--- a/race_regs_all_exc.php
+++ b/race_regs_all_exc.php
@@ -1,6 +1,14 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$gr_id = $_REQUEST['gr_id'] ?? null;
+$id = $_REQUEST['id'] ?? null;
+$kateg = $_REQUEST['kateg'] ?? null;
+$pozn = $_REQUEST['pozn'] ?? null;
+$pozn2 = $_REQUEST['pozn2'] ?? null;
+$transport = $_REQUEST['transport'] ?? null;
+$sedadel = $_REQUEST['sedadel'] ?? null;
+$ubytovani = $_REQUEST['ubytovani'] ?? null;
+$term = $_REQUEST['term'] ?? null;
 
 //TBD: podpora entry_locked
 

--- a/race_show_all.php
+++ b/race_show_all.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$old = $_REQUEST['old'] ?? null;
 
 require_once ("./timestamp.inc.php");
 _set_global_RT_Start();

--- a/srv_repair_regs_db.php
+++ b/srv_repair_regs_db.php
@@ -1,7 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php /* adminova stranka - oprava tabulky usxzav */
 
-@extract($_REQUEST, EXTR_SKIP);
+
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/sys_log.php
+++ b/sys_log.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+
 
 require_once('./cfg/_uc.php');
 require_once("./cfg/_colors.php");

--- a/us_mailinfo_exc.php
+++ b/us_mailinfo_exc.php
@@ -1,6 +1,20 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$notify_type = $_REQUEST['notify_type'] ?? null;
+$racetype = $_REQUEST['racetype'] ?? null;
+$zebricek = $_REQUEST['zebricek'] ?? null;
+$daysbefore = $_REQUEST['daysbefore'] ?? null;
+$ch_data = $_REQUEST['ch_data'] ?? null;
+$active_tf = $_REQUEST['active_tf'] ?? null;
+$active_ch = $_REQUEST['active_ch'] ?? null;
+$active_rg = $_REQUEST['active_rg'] ?? null;
+$active_fin = $_REQUEST['active_fin'] ?? null;
+$active_finf = $_REQUEST['active_finf'] ?? null;
+$active_news = $_REQUEST['active_news'] ?? null;
+$fin_limit = $_REQUEST['fin_limit'] ?? null;
+$fin_type = $_REQUEST['fin_type'] ?? null;
+$email = $_REQUEST['email'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/us_race_regoff_exc.php
+++ b/us_race_regoff_exc.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
+$id_us = $_REQUEST['id_us'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/us_race_regon.php
+++ b/us_race_regon.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
+$id_us = $_REQUEST['id_us'] ?? null;
 
 require_once('./cfg/_colors.php');
 require_once('./connect.inc.php');

--- a/us_race_regon_exc.php
+++ b/us_race_regon_exc.php
@@ -1,6 +1,15 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php
-@extract($_REQUEST, EXTR_SKIP);
+$id_zav = $_REQUEST['id_zav'] ?? null;
+$id_us = $_REQUEST['id_us'] ?? null;
+$id_z = $_REQUEST['id_z'] ?? null;
+$kat = $_REQUEST['kat'] ?? null;
+$pozn = $_REQUEST['pozn'] ?? null;
+$pozn2 = $_REQUEST['pozn2'] ?? null;
+$sedadel = $_REQUEST['sedadel'] ?? null;
+$transport = $_REQUEST['transport'] ?? null;
+$ubytovani = $_REQUEST['ubytovani'] ?? null;
+$novy = $_REQUEST['novy'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/us_setup_exc.php
+++ b/us_setup_exc.php
@@ -1,6 +1,13 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php /* clenova stranka - provedeni zmeny informaci a nastaveni */
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$type = $_REQUEST['type'] ?? null;
+$login = $_REQUEST['login'] ?? null;
+$podpis = $_REQUEST['podpis'] ?? null;
+$hesloo = $_REQUEST['hesloo'] ?? null;
+$oldheslo = $_REQUEST['oldheslo'] ?? null;
+$heslo = $_REQUEST['heslo'] ?? null;
+$heslo2 = $_REQUEST['heslo2'] ?? null;
 
 require_once('./connect.inc.php');
 require_once('./sess.inc.php');

--- a/user_del_exc.php
+++ b/user_del_exc.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php /* adminova stranka - provedeni smazani clena */
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once ('./connect.inc.php');
 require_once ('./common.inc.php');

--- a/user_edit.php
+++ b/user_edit.php
@@ -1,7 +1,8 @@
 <?php /* adminova stranka - editace clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$cb = $_REQUEST['cb'] ?? null;
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/user_finance_type.php
+++ b/user_finance_type.php
@@ -1,7 +1,7 @@
 <?php
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$user_id = $_REQUEST['user_id'] ?? null;
 
 require_once ("connect.inc.php");
 require_once ("sess.inc.php");

--- a/user_finance_type_exc.php
+++ b/user_finance_type_exc.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$user_id = $_REQUEST['user_id'] ?? null;
+$type = $_REQUEST['type'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/user_finance_view.php
+++ b/user_finance_view.php
@@ -1,7 +1,18 @@
 <?php /* maly trener - zobrazeni detailu financi pro clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$payment = $_REQUEST['payment'] ?? null;
+$trn_id = $_REQUEST['trn_id'] ?? null;
+$id_zavod = $_REQUEST['id_zavod'] ?? null;
+$amount = $_REQUEST['amount'] ?? null;
+$id_from = $_REQUEST['id_from'] ?? null;
+$id_to = $_REQUEST['id_to'] ?? null;
+$note = $_REQUEST['note'] ?? null;
+$user_id = $_REQUEST['user_id'] ?? null;
+$datum = $_REQUEST['datum'] ?? null;
+$storno_note = $_REQUEST['storno_note'] ?? null;
+$change = $_REQUEST['change'] ?? null;
+$storno = $_REQUEST['storno'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/user_hide_exc.php
+++ b/user_hide_exc.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once('./connect.inc.php');
 require_once('./sess.inc.php');

--- a/user_lock2_exc.php
+++ b/user_lock2_exc.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+ $gr_id = $_REQUEST['gr_id'] ?? null;
+ $id = $_REQUEST['id'] ?? null;
 
 require_once('./connect.inc.php');
 require_once('./sess.inc.php');

--- a/user_lock_exc.php
+++ b/user_lock_exc.php
@@ -1,6 +1,6 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once('./connect.inc.php');
 require_once('./sess.inc.php');

--- a/user_login_edit.php
+++ b/user_login_edit.php
@@ -1,6 +1,7 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$cb = $_REQUEST['cb'] ?? null;
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");

--- a/user_login_edit_exc.php
+++ b/user_login_edit_exc.php
@@ -1,6 +1,21 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$type = $_REQUEST['type'] ?? null;
+$action_type = $_REQUEST['action_type'] ?? null;
+$news = $_REQUEST['news'] ?? null;
+$regs = $_REQUEST['regs'] ?? null;
+$mng = $_REQUEST['mng'] ?? null;
+$mng2 = $_REQUEST['mng2'] ?? null;
+$adm = $_REQUEST['adm'] ?? null;
+$fin = $_REQUEST['fin'] ?? null;
+$login = $_REQUEST['login'] ?? null;
+$podpis = $_REQUEST['podpis'] ?? null;
+$login_g = $_REQUEST['login_g'] ?? null;
+$podpis_g = $_REQUEST['podpis_g'] ?? null;
+$nheslo = $_REQUEST['nheslo'] ?? null;
+$nheslo2 = $_REQUEST['nheslo2'] ?? null;
+$email = $_REQUEST['email'] ?? null;
 
 require_once('./connect.inc.php');
 require_once('./sess.inc.php');

--- a/user_new_exc.php
+++ b/user_new_exc.php
@@ -1,6 +1,27 @@
 <? define("__HIDE_TEST__", "_KeAr_PHP_WEB_"); ?>
 <?php /* adminova stranka - provedeni vlozeni clena */
-@extract($_REQUEST, EXTR_SKIP);
+$fin = $_REQUEST['fin'] ?? null;
+$rc = $_REQUEST['rc'] ?? null;
+$hidden = $_REQUEST['hidden'] ?? null;
+$bank_account = $_REQUEST['bank_account'] ?? null;
+$datum = $_REQUEST['datum'] ?? null;
+$prijmeni = $_REQUEST['prijmeni'] ?? null;
+$jmeno = $_REQUEST['jmeno'] ?? null;
+$update = $_REQUEST['update'] ?? null;
+$adresa = $_REQUEST['adresa'] ?? null;
+$mesto = $_REQUEST['mesto'] ?? null;
+$psc = $_REQUEST['psc'] ?? null;
+$domu = $_REQUEST['domu'] ?? null;
+$zam = $_REQUEST['zam'] ?? null;
+$mobil = $_REQUEST['mobil'] ?? null;
+$email = $_REQUEST['email'] ?? null;
+$reg = $_REQUEST['reg'] ?? null;
+$si = $_REQUEST['si'] ?? null;
+$poh = $_REQUEST['poh'] ?? null;
+$lic = $_REQUEST['lic'] ?? null;
+$lic_mtbo = $_REQUEST['lic_mtbo'] ?? null;
+$lic_lob = $_REQUEST['lic_lob'] ?? null;
+$narodnost = $_REQUEST['narodnost'] ?? null;
 
 require_once ('./connect.inc.php');
 require_once ('./sess.inc.php');

--- a/user_view.php
+++ b/user_view.php
@@ -1,7 +1,7 @@
 <?php /* adminova stranka - editace clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once("./cfg/_globals.php");

--- a/view_address.php
+++ b/view_address.php
@@ -1,7 +1,7 @@
 <?php /* adminova stranka - editace clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");

--- a/view_adm_user_detail.php
+++ b/view_adm_user_detail.php
@@ -1,7 +1,11 @@
 <? /* adminova stranka - detail clena */
 define("__HIDE_TEST__", "_KeAr_PHP_WEB_");
 
-@extract($_REQUEST, EXTR_SKIP);
+$id = $_REQUEST['id'] ?? null;
+$edit = $_REQUEST['edit'] ?? null;
+$hidden = $_REQUEST['hidden'] ?? null;
+$entry_locked = $_REQUEST['entry_locked'] ?? null;
+$locked = $_REQUEST['locked'] ?? null;
 
 require_once("./cfg/_colors.php");
 require_once ("./connect.inc.php");


### PR DESCRIPTION
Replace all extract($_REQUEST), extract($_POST), extract($_GET) and extract($required_data) calls across 69 files with direct variable assignments using null coalescing operator. This eliminates a security risk and improves code clarity by making variable origins explicit.