### PR TITLE
ORIS: výběr etap pro vícedenní (etapové) závody

### DIFF
--- a/_SQL/zmeny.sql.php
+++ b/_SQL/zmeny.sql.php
@@ -31,6 +31,7 @@ AddZmenyFile('3.4.5.655');
 AddZmenyFile('3.4.5.658');
 AddZmenyFile('3.4.6.656');
 AddZmenyFile('3.4.7.660');
+AddZmenyFile('3.5.1.673');
 //#############################################################################
 
 require_once ('connect.inc.php');

--- a/_SQL/zmeny_3.5.1.673.sql.php
+++ b/_SQL/zmeny_3.5.1.673.sql.php
@@ -1,0 +1,20 @@
+<?
+// zmeny pro verzi 3.5.1.673 - podpora vyberu etap pro vicedenni (etapove) zavody v ORIS synchronizaci
+
+$version_upd = '3.5.1.673';
+
+//#############################################################################
+
+require_once ('prepare.inc.php');
+
+//#############################################################################
+//	SQL dotazy pro zmenu db. na novejsi verzi
+//#############################################################################
+
+# *** do tabulky zavxus pridej sloupec pro vyber etap (napr. "1,2,3"), ORIS API vyzaduje stageX parametr
+$sql[0] = "ALTER TABLE `".TBL_ZAVXUS."` ADD COLUMN `etapy` VARCHAR(20) NULL DEFAULT NULL AFTER `si_chip`";
+
+//#############################################################################
+
+require_once ('action.inc.php');
+?>

--- a/common_race.inc.php
+++ b/common_race.inc.php
@@ -548,7 +548,7 @@ function ParseEtapyString($etapy) {
 function RenderEtapyCheckboxes($etapCount, array $selected, $inputName = 'etapy[]') {
 	for ($e = 1; $e <= (int)$etapCount; $e++) {
 		$checked = in_array($e, $selected) ? ' checked' : '';
-		echo '<label><input type="checkbox" name="'.$inputName.'" value="'.$e.'"'.$checked.'> Etapa '.$e.'</label>&nbsp;&nbsp;';
+		echo '<label><input type="checkbox" name="'.$inputName.'" value="'.$e.'"'.$checked.'> Etapa '.$e.'</label> ';
 	}
 }
 

--- a/common_race.inc.php
+++ b/common_race.inc.php
@@ -521,4 +521,35 @@ function RenderCategoryCounts ( array $category_counts ) {
 	</script>';
 }
 
+// vicedenni (etapovy) zavod s vice nez 1 etapou - ORIS vyzaduje vyber etap pri prihlasce
+function IsMultiEtapaRace($race) {
+	return is_array($race) && !empty($race['vicedenni']) && (int)($race['etap'] ?? 0) > 1;
+}
+
+// serazeny, deduplikovany seznam cisel etap (1..N) jako retezec "1,2,3"
+function BuildEtapyString(array $stages) {
+	$stages = array_unique(array_map('intval', $stages));
+	sort($stages);
+	return implode(',', $stages);
+}
+
+// retezec se vsemi etapami zavodu, napr. pro 3 etapy "1,2,3"
+function AllEtapyString($etapCount) {
+	return implode(',', range(1, (int)$etapCount));
+}
+
+// rozparsuje ulozeny retezec "1,2,3" na pole celych cisel
+function ParseEtapyString($etapy) {
+	if (empty($etapy)) return [];
+	return array_values(array_filter(array_map('intval', explode(',', $etapy))));
+}
+
+// vykresli checkboxy pro vyber etap, $selected = pole cisel etap ktere maji byt zaskrtnute
+function RenderEtapyCheckboxes($etapCount, array $selected, $inputName = 'etapy[]') {
+	for ($e = 1; $e <= (int)$etapCount; $e++) {
+		$checked = in_array($e, $selected) ? ' checked' : '';
+		echo '<label><input type="checkbox" name="'.$inputName.'" value="'.$e.'"'.$checked.'> Etapa '.$e.'</label>&nbsp;&nbsp;';
+	}
+}
+
 ?>

--- a/ct_renderer_race.inc.php
+++ b/ct_renderer_race.inc.php
@@ -131,6 +131,7 @@ class RaceRendererFactory extends AColumnRendererFactory {
             'reg' => new HelpHeaderRenderer('Reg.č.',ALIGN_CENTER,"Registrační číslo"),
             'si_chip' => new DefaultHeaderRenderer('SI čip',ALIGN_RIGHT),
             'kat' => new KategoryHeadderRenderer('Kategorie',ALIGN_CENTER,"Zobrazí počet účastníků v jednotlivých kategoriích"),
+            'etapy' => new DefaultHeaderRenderer('Etapy',ALIGN_CENTER),
             'transport' => new HelpHeaderRenderer('SD',ALIGN_CENTER,"Společná"),
             'sedadel' => new HelpHeaderRenderer('&#x1F697;',ALIGN_CENTER,'Nabízených sedadel'),
             'ubytovani' => new HelpHeaderRenderer('SU',ALIGN_CENTER,"Společné ubytování"),

--- a/docker/Dockerfile.srv
+++ b/docker/Dockerfile.srv
@@ -1,4 +1,4 @@
-FROM php:8.2-apache as base
+FROM php:8.2-apache AS base
 
 # Install mysqli and clean up
 RUN docker-php-ext-install mysqli
@@ -22,7 +22,7 @@ Alias /members /var/www/html/members\n\
 
 EXPOSE 10100
 
-FROM base as autotest
+FROM base AS autotest
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
@@ -43,7 +43,7 @@ RUN chmod +x /usr/local/bin/members-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/members-entrypoint.sh"]
 
-FROM autotest as dev
+FROM autotest AS dev
 
 # Install common VS Code Container Tools dependencies.
 # bubblewrap is required for codex

--- a/docker/db_init/d235220_members_latest.sql
+++ b/docker/db_init/d235220_members_latest.sql
@@ -1236,6 +1236,7 @@ CREATE TABLE `tst_zavxus` (
   `pozn_in` varchar(255) DEFAULT NULL,
   `termin` tinyint(4) UNSIGNED NOT NULL DEFAULT 1,
   `si_chip` int(9) UNSIGNED NOT NULL DEFAULT 0,
+  `etapy` varchar(20) DEFAULT NULL,
   `transport` tinyint(1) DEFAULT NULL,
   `sedadel` tinyint(1) DEFAULT NULL,
   `ubytovani` tinyint(1) DEFAULT NULL,

--- a/functions.js
+++ b/functions.js
@@ -165,3 +165,29 @@ function toggleDisplayByData(key,value) {
         (lst[i].style.display == '')?(lst[i].style.display='none'):(lst[i].style.display='');
 	}
 }
+
+function selectAllRaceStagesForCategory(categoryInput)
+{
+	if (!categoryInput || categoryInput.value.trim() === '')
+		return;
+
+	var row = categoryInput.closest('tr');
+	if (!row)
+		return;
+
+	var stages = row.querySelectorAll('input[type="checkbox"][name^="etapy["]');
+	for (var i = 0; i < stages.length; i++)
+		stages[i].checked = true;
+}
+
+function registerRaceCategoryStageSelection()
+{
+	var categoryInputs = document.querySelectorAll('input[name^="kateg["]');
+	for (var i = 0; i < categoryInputs.length; i++)
+	{
+		categoryInputs[i].addEventListener('input', function(event) {
+			selectAllRaceStagesForCategory(event.target);
+		});
+	}
+}
+

--- a/functions.js
+++ b/functions.js
@@ -177,6 +177,12 @@ function selectAllRaceStagesForCategory(categoryInput)
 
 	var stages = row.querySelectorAll('input[type="checkbox"][name^="etapy["]');
 	for (var i = 0; i < stages.length; i++)
+	{
+		if (stages[i].checked)
+			return;
+	}
+
+	for (var i = 0; i < stages.length; i++)
 		stages[i].checked = true;
 }
 

--- a/lib/OrisDTOs.php
+++ b/lib/OrisDTOs.php
@@ -73,6 +73,8 @@ class OrisEntryRequestDTO {
     public int $rentSi;
     public ?string $note;
     public ?string $entryId;
+    public int $etapCount;
+    public array $selectedEtapy;
 
     public function __construct(
         ?string $clubuser,
@@ -80,7 +82,9 @@ class OrisEntryRequestDTO {
         ?string $si,
         bool $rentSi = false,
         ?string $note = null,
-        ?string $entryId = null
+        ?string $entryId = null,
+        int $etapCount = 0,
+        array $selectedEtapy = []
     ) {
         $this->clubuser = $clubuser;
         $this->classId = $classId;
@@ -88,6 +92,8 @@ class OrisEntryRequestDTO {
         $this->rentSi = $rentSi ? 1 : 0;
         $this->note = $note;
         $this->entryId = $entryId;
+        $this->etapCount = $etapCount;
+        $this->selectedEtapy = $selectedEtapy;
     }
 
     public function toArray(): array {
@@ -100,6 +106,10 @@ class OrisEntryRequestDTO {
         $data['rent_si'] = $this->rentSi ? 1 : 0;
         if ($this->note !== null && $this->note !== '') $data['note'] = $this->note;
         if ($this->entryId !== null) $data['entryid'] = $this->entryId;
+        // Vicedenni (etapovy) zavod - ORIS vyzaduje stageX=1/0 pro kazdou etapu 1..N
+        for ($stage = 1; $stage <= $this->etapCount; $stage++) {
+            $data['stage'.$stage] = in_array($stage, $this->selectedEtapy) ? 1 : 0;
+        }
         return $data;
     }
 }

--- a/lib/oris_sync.inc.php
+++ b/lib/oris_sync.inc.php
@@ -2,6 +2,7 @@
 require_once("connect.inc.php");
 require_once("lib/OrisIntegrationService.php");
 require_once("oris_user.class.php");
+require_once("common_race.inc.php");
 
 function processEntry($row, $action, $service) {
     global $g_shortcut;
@@ -142,6 +143,19 @@ function processEntry($row, $action, $service) {
     $rentSi = $row['rent_si'] ?? 0;
     $note = $row['pozn'] ?? '';
 
+    $etapCount = IsMultiEtapaRace($raceRow) ? (int)$raceRow['etap'] : 0;
+    $selectedEtapy = $etapCount > 0 ? ParseEtapyString($row['etapy'] ?? null) : [];
+
+    if ($etapCount > 0 && $action !== 'delete' && empty($selectedEtapy)) {
+        $errorPayload = correct_sql_string(json_encode(['status' => 'error', 'message' => 'Je třeba vybrat alespoň jednu etapu.']));
+        $failedStatus = 'FAILED_' . strtoupper($action);
+        $res = query_db("UPDATE `" . TBL_ZAVXUS . "` SET `sync_status` = '$failedStatus', `sync_error_payload` = '$errorPayload' WHERE `id` = " . (int)$id);
+        if (!$res) {
+            query_db("UPDATE `" . TBL_ZAVXUS . "` SET `sync_error_payload` = '$errorPayload' WHERE `id` = " . (int)$id);
+        }
+        return false;
+    }
+
     if (empty($clubuser)) {
         $errorPayload = correct_sql_string(json_encode(['status' => 'error', 'message' => 'Chybí ORIS ID uživatele v klubu (clubuser).']));
         $failedStatus = 'FAILED_' . strtoupper($action);
@@ -174,11 +188,11 @@ function processEntry($row, $action, $service) {
             }
 
             if (!empty($existingEntryId)) {
-                $updateDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note, $existingEntryId);
+                $updateDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note, $existingEntryId, $etapCount, $selectedEtapy);
                 $response = $service->updateEntry($updateDto);
                 $action = 'update';
             } else {
-                $createDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note);
+                $createDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note, null, $etapCount, $selectedEtapy);
                 $response = $service->createEntry($createDto);
             }
         } elseif ($action === 'update') {
@@ -202,10 +216,10 @@ function processEntry($row, $action, $service) {
 
             if (empty($entryIdToUpdate)) {
                 // Fall back to create if no existing entry found
-                $createDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note);
+                $createDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note, null, $etapCount, $selectedEtapy);
                 $response = $service->createEntry($createDto);
             } else {
-                $updateDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note, $entryIdToUpdate);
+                $updateDto = new OrisEntryRequestDTO($clubuser, $classId, $si, (bool)$rentSi, $note, $entryIdToUpdate, $etapCount, $selectedEtapy);
                 $response = $service->updateEntry($updateDto);
             }
         } elseif ($action === 'delete') {

--- a/mocks/oris/README.md
+++ b/mocks/oris/README.md
@@ -50,12 +50,18 @@ The server listens on port `10301` by default.
 - `POST /__testbench/api/races/:eventId/services`
 
 Race create/update accepts `proxy_only` (`1` for mock/local-only, `0` for upstream overlay).
+Mock multistage races can link their component events with `stage1`, `stage2`, and
+`stage3` (or the equivalent ORIS-style `Stage1`, `Stage2`, and `Stage3` fields).
 Race sport is stored by name (`OB`, `LOB`, `MTBO`, or `TRAIL`) in an enum column.
 Levels are stored by name (for example `MČR,OŽ`), while regions continue to use ORIS region IDs.
 For compatibility, race input may use either names (`sport`, `levels`) or ORIS IDs (`sportId`, `levelIds`).
 When omitted, `entryStart` remains empty for newly created races.
 When an upstream overlay race is saved, the mock fetches the upstream event and stores all returned classes in the mock database so later local entry mutations can resolve `class` IDs without another event lookup.
 Successful upstream `getEvent` requests through the mock also refresh the stored class snapshot.
+Participant `stages` values are stored as comma-separated, one-based stage indexes (for example `1,3`).
+ORIS-compatible `createEntry` and `updateEntry` calls accept stage flags such as
+`stage1=1&stage2=0&stage3=1`; a multistage entry must select at least one stage.
+`getEventEntries` exposes the selection as a `Stages` object containing `Stage1`, `Stage2`, and so on.
 
 The API log path can be overridden with `ORIS_MOCK_API_LOG_FILE`.
 

--- a/mocks/oris/src/server.ts
+++ b/mocks/oris/src/server.ts
@@ -31,6 +31,9 @@ type EventRow = MockRow & {
   name: string | null;
   place: string | null;
   stages: number | null;
+  stage1_id: string | null;
+  stage2_id: string | null;
+  stage3_id: string | null;
   sport_id: string | null;
   level_id: string | null;
   ranking: string | null;
@@ -79,6 +82,7 @@ type EntryRow = MockRow & {
   entry_stop: number | null;
   si: string | null;
   note: string | null;
+  stages: string | null;
 };
 
 type ServiceRow = MockRow & {
@@ -183,6 +187,10 @@ function apiClosedRegistration(method: string): JsonObject {
     ExportCreated: new Date().toISOString().slice(0, 19).replace('T', ' '),
     Data: [],
   };
+}
+
+function apiMissingStages(): JsonObject {
+  return { Status: 'Je třeba vybrat alespoň jednu etapu', Data: {} };
 }
 
 function isPlainObject(value: unknown): value is JsonObject {
@@ -501,6 +509,9 @@ async function ensureDatabase(): Promise<void> {
       name VARCHAR(255) NULL,
       place VARCHAR(255) NULL,
       stages INT NULL,
+      stage1_id VARCHAR(32) NULL,
+      stage2_id VARCHAR(32) NULL,
+      stage3_id VARCHAR(32) NULL,
       sport_id ENUM('OB', 'LOB', 'MTBO', 'TRAIL') NULL,
       level_id VARCHAR(255) NULL,
       ranking VARCHAR(32) NULL,
@@ -519,6 +530,13 @@ async function ensureDatabase(): Promise<void> {
       INDEX idx_date (date),
       INDEX idx_deleted (deleted)
     )
+  `);
+
+  await pool.query(`
+    ALTER TABLE mock_events
+    ADD COLUMN IF NOT EXISTS stage1_id VARCHAR(32) NULL AFTER stages,
+    ADD COLUMN IF NOT EXISTS stage2_id VARCHAR(32) NULL AFTER stage1_id,
+    ADD COLUMN IF NOT EXISTS stage3_id VARCHAR(32) NULL AFTER stage2_id
   `);
 
   await pool.query(`
@@ -571,12 +589,18 @@ async function ensureDatabase(): Promise<void> {
       entry_stop INT NULL,
       si VARCHAR(32) NULL,
       note VARCHAR(512) NULL,
+      stages VARCHAR(255) NULL,
       proxy_only TINYINT(1) NOT NULL DEFAULT 1,
       deleted TINYINT(1) NOT NULL DEFAULT 0,
       updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
       INDEX idx_event (event_id, deleted),
       INDEX idx_club_user (club_user_id)
     )
+  `);
+
+  await pool.query(`
+    ALTER TABLE mock_entries
+    ADD COLUMN IF NOT EXISTS stages VARCHAR(255) NULL AFTER note
   `);
 
   await pool.query(`
@@ -834,6 +858,9 @@ function composeEvent(row: EventRow, classRows: EventClassRow[], upstreamEvent: 
   overlayValue(row.name, (value) => { overlay.Name = value; });
   overlayValue(row.place, (value) => { overlay.Place = value; });
   overlayValue(row.stages, (value) => { overlay.Stages = Number(value); });
+  overlayValue(row.stage1_id, (value) => { overlay.Stage1 = value; });
+  overlayValue(row.stage2_id, (value) => { overlay.Stage2 = value; });
+  overlayValue(row.stage3_id, (value) => { overlay.Stage3 = value; });
   overlayValue(row.sport_id, (value) => { overlay.Sport = composeSport(value); });
   overlayValue(row.level_id, (value) => { overlay.Level = composeLevel(value); });
   overlayValue(row.ranking, (value) => { overlay.Ranking = value; });
@@ -913,6 +940,7 @@ function composeEntry(row: EntryRow, upstreamEntry: JsonObject | null, event: Js
       EntryStop: 1,
       SI: asString(user?.SI, ''),
       Note: '',
+      Stages: composeEntryStages(row.stages, event),
     }
     : { ...upstreamEntry };
 
@@ -930,7 +958,46 @@ function composeEntry(row: EntryRow, upstreamEntry: JsonObject | null, event: Js
   overlayValue(row.entry_stop, (value) => { overlay.EntryStop = Number(value); });
   overlayValue(row.si, (value) => { overlay.SI = value; });
   overlayValue(row.note, (value) => { overlay.Note = value; });
+  overlayValue(row.stages, (value) => { overlay.Stages = composeEntryStages(value, event); });
   return mergeJson(base, overlay);
+}
+
+function eventStageCount(event: JsonObject | null): number {
+  return Math.max(1, Math.trunc(asNumber(event?.Stages, 1)));
+}
+
+function stageIndexes(value: unknown, stageCount: number): number[] {
+  const indexes = Array.isArray(value) ? value : asString(value).split(',');
+  return Array.from(new Set(indexes
+    .map((item) => Math.trunc(Number(item)))
+    .filter((index) => Number.isFinite(index) && index >= 1 && index <= stageCount)))
+    .sort((left, right) => left - right);
+}
+
+function inputStageIndexes(input: JsonObject, event: JsonObject | null): number[] {
+  const stageCount = eventStageCount(event);
+  if (Object.prototype.hasOwnProperty.call(input, 'stages')) {
+    return stageIndexes(input.stages, stageCount);
+  }
+  if (Object.prototype.hasOwnProperty.call(input, 'Stages') && !isPlainObject(input.Stages)) {
+    return stageIndexes(input.Stages, stageCount);
+  }
+
+  const indexes: number[] = [];
+  for (let index = 1; index <= stageCount; index += 1) {
+    if (asBool(input[`stage${index}`] ?? input[`Stage${index}`])) indexes.push(index);
+  }
+  return indexes;
+}
+
+function composeEntryStages(value: unknown, event: JsonObject | null): JsonObject {
+  const stageCount = eventStageCount(event);
+  const selected = new Set(stageCount === 1 ? [1] : stageIndexes(value, stageCount));
+  const stages: JsonObject = {};
+  for (let index = 1; index <= stageCount; index += 1) {
+    stages[`Stage${index}`] = selected.has(index) ? 1 : 0;
+  }
+  return stages;
 }
 
 function composeService(row: ServiceRow, upstreamService: JsonObject | null): JsonObject {
@@ -985,9 +1052,10 @@ async function findEventByClass(classId: string): Promise<JsonObject | null> {
 type EntryMutationValidation =
   | { type: 'ok' }
   | { type: 'closedRegistration' }
+  | { type: 'missingStages' }
   | { type: 'error'; message: string };
 
-function validateEntryMutation(event: JsonObject | null, classId: string): EntryMutationValidation {
+function validateEntryMutation(event: JsonObject | null, classId: string, input: JsonObject = {}): EntryMutationValidation {
   if (!event) {
     return { type: 'error', message: `Class ${classId || '(missing)'} is not defined for an event.` };
   }
@@ -997,12 +1065,23 @@ function validateEntryMutation(event: JsonObject | null, classId: string): Entry
     return { type: 'error', message: `Class ${classId || '(missing)'} is not defined for event ${asString(event.ID)}.` };
   }
 
-  const deadline = normalizeDateTimeValue(event.EntryDate1).replace(' ', 'T');
-  if (deadline) {
+  if (eventStageCount(event) > 1 && inputStageIndexes(input, event).length === 0) {
+    return { type: 'missingStages' };
+  }
+
+  const deadlineTimestamps = [
+    event.EntryDate1,
+    event.EntryDate2,
+    event.EntryDate3,
+  ].flatMap((value) => {
+    const deadline = normalizeDateTimeValue(value).replace(' ', 'T');
+    if (!deadline) return [];
     const timestamp = Date.parse(`${deadline}Z`);
-    if (Number.isFinite(timestamp) && timestamp < Date.now()) {
-      return { type: 'closedRegistration' };
-    }
+    return Number.isFinite(timestamp) ? [timestamp] : [];
+  });
+  const deadline = Math.max(...deadlineTimestamps);
+  if (deadlineTimestamps.length > 0 && deadline < Date.now()) {
+    return { type: 'closedRegistration' };
   }
 
   return { type: 'ok' };
@@ -1166,16 +1245,20 @@ async function upsertEvent(input: JsonObject): Promise<JsonObject> {
   await pool.query(
     `
       INSERT INTO mock_events (
-        id, date, name, place, stages, sport_id, level_id, ranking, entry_date1, entry_date2,
+        id, date, name, place, stages, stage1_id, stage2_id, stage3_id,
+        sport_id, level_id, ranking, entry_date1, entry_date2,
         entry_date3, entry_koef2, entry_koef3, entry_start, org_abbr, region_id, cancelled,
         proxy_only, deleted
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
       ON DUPLICATE KEY UPDATE
         date = COALESCE(VALUES(date), date),
         name = COALESCE(VALUES(name), name),
         place = COALESCE(VALUES(place), place),
         stages = COALESCE(VALUES(stages), stages),
+        stage1_id = COALESCE(VALUES(stage1_id), stage1_id),
+        stage2_id = COALESCE(VALUES(stage2_id), stage2_id),
+        stage3_id = COALESCE(VALUES(stage3_id), stage3_id),
         sport_id = COALESCE(VALUES(sport_id), sport_id),
         level_id = COALESCE(VALUES(level_id), level_id),
         ranking = COALESCE(VALUES(ranking), ranking),
@@ -1197,6 +1280,9 @@ async function upsertEvent(input: JsonObject): Promise<JsonObject> {
       nullableString(input, 'name', 'Name'),
       nullableString(input, 'place', 'Place'),
       nullableNumber(input, 'stages', 'Stages') ?? (proxyOnly ? 1 : null),
+      nullableString(input, 'stage1', 'Stage1') ?? (generatedRace ? id : null),
+      nullableString(input, 'stage2', 'Stage2'),
+      nullableString(input, 'stage3', 'Stage3'),
       nullableSportName(input, 'sport', 'sportId', 'Sport') ?? (generatedRace ? 'OB' : null),
       nullableLevelNames(input, 'levels', 'levelIds', 'levelId', 'Level') ?? (generatedRace ? 'OŽ' : null),
       nullableString(input, 'ranking', 'Ranking') ?? (generatedRace ? '1' : null),
@@ -1287,13 +1373,14 @@ async function upsertEntry(input: JsonObject): Promise<JsonObject> {
 
   const classId = nullableString(input, 'classId', 'class', 'ClassID') ?? (isPlainObject(input.Class) ? nullableString(input.Class, 'ID') : null);
   const classDesc = nullableString(input, 'classDesc', 'ClassDesc') ?? (isPlainObject(input.Class) ? nullableString(input.Class, 'Name') : null);
+  const stages = inputStageIndexes(input, event).join(',') || null;
   await pool.query(
     `
       INSERT INTO mock_entries (
         entry_id, event_id, club_user_id, reg_no, class_id, class_desc, name, rent_si, licence,
-        fee, entry_stop, si, note, proxy_only, deleted
+        fee, entry_stop, si, note, stages, proxy_only, deleted
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
       ON DUPLICATE KEY UPDATE
         event_id = VALUES(event_id),
         club_user_id = COALESCE(VALUES(club_user_id), club_user_id),
@@ -1307,6 +1394,7 @@ async function upsertEntry(input: JsonObject): Promise<JsonObject> {
         entry_stop = COALESCE(VALUES(entry_stop), entry_stop),
         si = COALESCE(VALUES(si), si),
         note = COALESCE(VALUES(note), note),
+        stages = COALESCE(VALUES(stages), stages),
         proxy_only = VALUES(proxy_only),
         deleted = 0
     `,
@@ -1324,6 +1412,7 @@ async function upsertEntry(input: JsonObject): Promise<JsonObject> {
       nullableNumber(input, 'entryStop', 'EntryStop'),
       nullableString(input, 'si', 'SI'),
       nullableString(input, 'note', 'Note'),
+      stages,
       proxyOnly ? 1 : 0,
     ],
   );
@@ -1520,11 +1609,13 @@ async function handleCreateEntry(req: Request, res: Response): Promise<void> {
   try {
     const classId = asString(req.body.class);
     const event = await findEventByClass(classId);
-    const validation = validateEntryMutation(event, classId);
+    const validation = validateEntryMutation(event, classId, req.body);
     if (validation.type !== 'ok') {
       res.json(validation.type === 'closedRegistration'
         ? apiClosedRegistration('createEntry')
-        : apiError(validation.message));
+        : validation.type === 'missingStages'
+          ? apiMissingStages()
+          : apiError(validation.message));
       return;
     }
 
@@ -1557,11 +1648,13 @@ async function handleUpdateEntry(req: Request, res: Response): Promise<void> {
     return;
   }
   const classId = asString(req.body.class ?? rows[0].class_id);
-  const validation = validateEntryMutation(await getEvent(rows[0].event_id), classId);
+  const validation = validateEntryMutation(await getEvent(rows[0].event_id), classId, req.body);
   if (validation.type !== 'ok') {
     res.json(validation.type === 'closedRegistration'
       ? apiClosedRegistration('updateEntry')
-      : apiError(validation.message));
+      : validation.type === 'missingStages'
+        ? apiMissingStages()
+        : apiError(validation.message));
     return;
   }
   const entry = await upsertEntry({
@@ -1787,6 +1880,7 @@ function renderTestbenchPage(
       <td>${escapeHtml(eventLabel(row.event_id))}</td>
       <td>${escapeHtml(userLabel(userId))}</td>
       <td>${escapeHtml(row.class_desc ?? row.class_id)}</td>
+      <td>${escapeHtml(row.stages)}</td>
       <td class="links">
         ${apiLink('getEventEntries', { method: 'getEventEntries', eventid: row.event_id })}
         ${apiLink('getEvent', { method: 'getEvent', id: row.event_id })}
@@ -1896,7 +1990,7 @@ function renderTestbenchPage(
     </section>
     <section id="tab-participants" class="tab">
       <div class="toolbar"><h2>Participants</h2><button type="button" class="create-row" data-table="participants">Create</button></div>
-      <div class="table-wrap"><table><thead><tr><th>Entry ID</th><th>Race</th><th>User</th><th>Class</th><th>API requests</th><th>Action</th></tr></thead><tbody>${entryRows}</tbody></table></div>
+      <div class="table-wrap"><table><thead><tr><th>Entry ID</th><th>Race</th><th>User</th><th>Class</th><th>Stages</th><th>API requests</th><th>Action</th></tr></thead><tbody>${entryRows}</tbody></table></div>
     </section>
     <section id="tab-network" class="tab">
       <div class="toolbar"><h2>Network</h2></div>
@@ -1992,6 +2086,7 @@ function renderTestbenchPage(
         { name: 'entryStop', row: 'entry_stop', label: 'Entry stop', type: 'number' },
         { name: 'si', row: 'si', label: 'SI' },
         { name: 'note', row: 'note', label: 'Note', type: 'textarea', wide: true },
+        { name: 'stages', row: 'stages', label: 'Stages', wide: true },
       ],
     };
 

--- a/playwright.bank-errors.config.js
+++ b/playwright.bank-errors.config.js
@@ -1,9 +1,15 @@
 const { defineConfig } = require('@playwright/test');
 
 const baseConfig = require('./playwright.config');
+const projects = baseConfig.projects.map((project) => (
+  project.name === 'chromium'
+    ? { ...project, testIgnore: '**/member-7203.setup.js' }
+    : project
+));
 
 module.exports = defineConfig({
   ...baseConfig,
   testIgnore: undefined,
   testMatch: ['**/bank-connector-errors.spec.js'],
+  projects,
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,7 +22,16 @@ module.exports = defineConfig({
   },
   projects: [
     {
+      name: 'member-7203-setup',
+      testMatch: '**/member-7203.setup.js',
+    },
+    {
       name: 'chromium',
+      testIgnore: [
+        '**/bank-connector-errors.spec.js',
+        '**/member-7203.setup.js',
+      ],
+      dependencies: ['member-7203-setup'],
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/race_reg_view.php
+++ b/race_reg_view.php
@@ -26,7 +26,7 @@ DrawPageTitle('Seznam závodníků přihlášených na závod');
 
 db_Connect();
 
-$query = 'SELECT u.*, z.kat, z.pozn, z.pozn_in, z.termin, z.si_chip as t_si_chip, z.id_user, z.transport transport, z.sedadel, z.ubytovani ubytovani, z.sync_status FROM '.TBL_ZAVXUS.' as z, '.TBL_USER.' as u WHERE z.id_user = u.id AND z.id_zavod='.$id.' ORDER BY z.termin ASC, z.id ASC';
+$query = 'SELECT u.*, z.kat, z.pozn, z.pozn_in, z.termin, z.si_chip as t_si_chip, z.id_user, z.transport transport, z.sedadel, z.ubytovani ubytovani, z.etapy, z.sync_status FROM '.TBL_ZAVXUS.' as z, '.TBL_USER.' as u WHERE z.id_user = u.id AND z.id_zavod='.$id.' ORDER BY z.termin ASC, z.id ASC';
 @$vysledek=query_db($query);
 // Fetch all rows into array
 $zaznamy = $vysledek ? mysqli_fetch_all($vysledek, MYSQLI_ASSOC) : [];
@@ -58,6 +58,8 @@ $tbl_renderer->addColumns('id','jmeno','prijmeni');
 if ($us == 0) 
 	$tbl_renderer->addColumns('reg','si_chip');
 $tbl_renderer->addColumns('kat');
+if(IsMultiEtapaRace($zaznam_z))
+	$tbl_renderer->addColumns('etapy');
 if($is_spol_dopr_on||$is_sdil_dopr_on)
 	$tbl_renderer->addColumns('transport');
 if($is_sdil_dopr_on)

--- a/race_regs_1.php
+++ b/race_regs_1.php
@@ -84,7 +84,7 @@ echo('<FORM METHOD=POST ACTION="./race_regs_1_exc.php?gr_id='.$gr_id.'&id='.$id.
 
 $sub_query = (IsLoggedRegistrator() || IsLoggedManager()) ? '' : ' AND '.TBL_USER.'.chief_id = '.$usr->user_id.' OR '.TBL_USER.'.id = '.$usr->user_id;
 
-$query = 'SELECT '.TBL_USER.'.id, prijmeni, jmeno, reg, kat, pozn, pozn_in, termin, entry_locked, '.TBL_ZAVXUS.'.transport, '.TBL_ZAVXUS.'.sedadel, '.TBL_ZAVXUS.'.ubytovani FROM '.TBL_USER.' LEFT JOIN '.TBL_ZAVXUS.' ON '.TBL_USER.'.id = '.TBL_ZAVXUS.'.id_user AND '.TBL_ZAVXUS.'.id_zavod='.$id.' WHERE '.TBL_USER.'.hidden = 0'.$sub_query.' ORDER BY sort_name ASC';
+$query = 'SELECT '.TBL_USER.'.id, prijmeni, jmeno, reg, kat, pozn, pozn_in, termin, entry_locked, '.TBL_ZAVXUS.'.transport, '.TBL_ZAVXUS.'.sedadel, '.TBL_ZAVXUS.'.ubytovani, '.TBL_ZAVXUS.'.etapy FROM '.TBL_USER.' LEFT JOIN '.TBL_ZAVXUS.' ON '.TBL_USER.'.id = '.TBL_ZAVXUS.'.id_user AND '.TBL_ZAVXUS.'.id_zavod='.$id.' WHERE '.TBL_USER.'.hidden = 0'.$sub_query.' ORDER BY sort_name ASC';
 
 @$vysledek=query_db($query);
 
@@ -101,6 +101,8 @@ $is_sdil_dopr_on = ($zaznam_z["transport"]==3) && $g_enable_race_transport;
 $is_spol_dopr_auto = ($zaznam_z["transport"]==2) && $g_enable_race_transport;
 $is_spol_ubyt_on = ($zaznam_z["ubytovani"]==1) && $g_enable_race_accommodation;
 $is_spol_ubyt_auto = ($zaznam_z["ubytovani"]==2) && $g_enable_race_accommodation;
+$is_multi_etapa = IsMultiEtapaRace($zaznam_z);
+$etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
 
 $i=0;
 $us_rows = array();
@@ -119,6 +121,7 @@ while ($zaznam=mysqli_fetch_array($vysledek))
 				$us_rows[$i][4] = ($is_spol_dopr_on||$is_sdil_dopr_on) ? $zaznam['transport'] == 1 : 0;
 				$us_rows[$i][5] = ($is_sdil_dopr_on) ? $zaznam['sedadel'] : null;
 				$us_rows[$i][6] = ($is_spol_ubyt_on) ? $zaznam['ubytovani'] == 1 : 0;
+				$us_rows[$i][7] = ($is_multi_etapa) ? ($zaznam['etapy'] ?? '') : '';
 			}
 			else
 			{
@@ -143,7 +146,7 @@ echo'//<!--'."\n";
 echo 'us_rows = new Array('.sizeof($us_rows).');'."\n";
 foreach ($us_rows as $i => $value)
 {
-	echo 'us_rows['.$i.'] = ["'.$value[0].'","'.$value[1].'","'.$value[2].'","'.$value[3].'","'.($value[4] ? 'true' : 'false').'","'.$value[5].'","'.($value[6] ? 'true' : 'false').'"];'."\n";
+	echo 'us_rows['.$i.'] = ["'.$value[0].'","'.$value[1].'","'.$value[2].'","'.$value[3].'","'.($value[4] ? 'true' : 'false').'","'.$value[5].'","'.($value[6] ? 'true' : 'false').'","'.$value[7].'"];'."\n";
 }
 
 echo'//-->'."\n";
@@ -154,6 +157,15 @@ echo '<TD align="right">Kategorie</TD>';
 echo '<TD width="5"></TD>';
 echo '<TD><INPUT TYPE="text" NAME="kateg" SIZE=5></TD>';
 echo '</TR>';
+if($is_multi_etapa)
+{
+	echo '<TR>';
+	echo '<TD align="right">Etapy</TD>';
+	echo '<TD width="5"></TD>';
+	echo '<TD>';
+	RenderEtapyCheckboxes($etap_count, range(1, $etap_count));
+	echo '</TD></TR>';
+}
 if($is_spol_dopr_on)
 {
 	echo '<TR>';
@@ -245,7 +257,16 @@ function aktu_line()
 	if (us_rows[idx] != null)
 	{
 		document.form1.kateg.value=us_rows[idx][0];
-<? 
+<?
+	if($is_multi_etapa)
+	{
+?>
+		var selEtapy = us_rows[idx][7] ? us_rows[idx][7].split(",") : [];
+		document.form1.querySelectorAll('input[name="etapy[]"]').forEach(function(cb) {
+			cb.checked = (selEtapy.length == 0) || (selEtapy.indexOf(cb.value) != -1);
+		});
+<?
+	}
 	if($is_spol_dopr_on)
 	{
 ?>
@@ -283,6 +304,12 @@ function aktu_line()
 	{
 		document.form1.kateg.value="";
 <?
+	if($is_multi_etapa)
+	{
+?>
+		document.form1.querySelectorAll('input[name="etapy[]"]').forEach(function(cb) { cb.checked = true; });
+<?
+	}
 	if($is_spol_dopr_on)
 	{
 ?>

--- a/race_regs_1_exc.php
+++ b/race_regs_1_exc.php
@@ -11,6 +11,7 @@ $new_termin = $_REQUEST['new_termin'] ?? null;
 $transport = $_REQUEST['transport'] ?? null;
 $sedadel = $_REQUEST['sedadel'] ?? null;
 $ubytovani = $_REQUEST['ubytovani'] ?? null;
+$etapy = $_REQUEST['etapy'] ?? [];
 
 //TBD: podpora entry_locked
 
@@ -85,7 +86,15 @@ if ( $is_spol_dopr_on) {
 
 $ubytovani = ($is_spol_ubyt_on) ? $ubytovani : 0;
 
-if($termin != 0)
+$is_multi_etapa = IsMultiEtapaRace($zaznam_z);
+$etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
+$selected_etapy = $is_multi_etapa ? array_values(array_intersect(range(1, $etap_count), array_map('intval', (array)$etapy))) : [];
+$etapy_sql = $is_multi_etapa ? "'".BuildEtapyString($selected_etapy)."'" : 'NULL';
+
+if ($is_multi_etapa && $kateg != '' && empty($selected_etapy)) {
+	$sync_error = 'Musíte vybrat alespoň jednu etapu.';
+}
+else if($termin != 0)
 {
 	$sync_action = '';
 	$inserted_or_updated_id = 0;
@@ -128,7 +137,7 @@ if($termin != 0)
 				$sync_status_update = ", sync_status='PENDING_UPDATE'";
 			}
 			
-			$result=query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kateg', pozn='$pozn', pozn_in='$pozn2', termin='$termin', transport = '$transport', sedadel = ".$sedadel.", ubytovani = '$ubytovani'".$sync_status_update." WHERE id_zavod = '$id' AND id_user = '$user_id'")
+			$result=query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kateg', pozn='$pozn', pozn_in='$pozn2', termin='$termin', transport = '$transport', sedadel = ".$sedadel.", ubytovani = '$ubytovani', etapy = ".$etapy_sql.$sync_status_update." WHERE id_zavod = '$id' AND id_user = '$user_id'")
 				or die("Chyba při provádění dotazu do databáze.");
 			if ($result == FALSE)
 				die ("Nepodařilo se změnit přihlášku člena.");
@@ -150,7 +159,7 @@ if($termin != 0)
 			
 			$sync_status = !empty($zaznam_z['ext_id']) ? 'PENDING_CREATE' : 'LOCAL_ONLY';
 
-			$result=query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in,termin,transport,sedadel,ubytovani,sync_status) VALUES ('$user_id','$id','$kateg', '$pozn', '$pozn2','$termin','$transport',".$sedadel.",'$ubytovani','$sync_status')")
+			$result=query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in,termin,transport,sedadel,ubytovani,etapy,sync_status) VALUES ('$user_id','$id','$kateg', '$pozn', '$pozn2','$termin','$transport',".$sedadel.",'$ubytovani',".$etapy_sql.",'$sync_status')")
 				or die("Chyba při provádění dotazu do databáze.");
 			if ($result == FALSE)
 				die ("Nepodařilo se změnit přihlášku člena.");
@@ -205,9 +214,10 @@ if($termin != 0)
 							$prev_transport = (int)$previous_state['transport'];
 							$prev_sedadel = (!isset($previous_state['sedadel']) || $previous_state['sedadel'] === null) ? 'null' : (int)$previous_state['sedadel'];
 							$prev_ubytovani = (!isset($previous_state['ubytovani']) || $previous_state['ubytovani'] === null) ? 'null' : (int)$previous_state['ubytovani'];
+							$prev_etapy = empty($previous_state['etapy']) ? 'NULL' : "'".correct_sql_string($previous_state['etapy'])."'";
 							$prev_sync_status = correct_sql_string($previous_state['sync_status']);
 
-							query_db("UPDATE ".TBL_ZAVXUS." SET kat='$prev_kat', pozn='$prev_pozn', pozn_in='$prev_pozn_in', termin='$prev_termin', transport=$prev_transport, sedadel=$prev_sedadel, ubytovani=$prev_ubytovani, sync_status='$prev_sync_status' WHERE id='$inserted_or_updated_id'");
+							query_db("UPDATE ".TBL_ZAVXUS." SET kat='$prev_kat', pozn='$prev_pozn', pozn_in='$prev_pozn_in', termin='$prev_termin', transport=$prev_transport, sedadel=$prev_sedadel, ubytovani=$prev_ubytovani, etapy=$prev_etapy, sync_status='$prev_sync_status' WHERE id='$inserted_or_updated_id'");
 						}
 					}
 				}

--- a/race_regs_all.php
+++ b/race_regs_all.php
@@ -90,10 +90,14 @@ function zmen_kat(kat)
 	if (focused_row != -1)
 	{
 		kat_name = 'kateg[' + focused_row +']';
-		document.form1.elements[kat_name].value = kat;
+		kat_input = document.form1.elements[kat_name];
+		kat_input.value = kat;
+		selectAllRaceStagesForCategory(kat_input);
 	}
 	return false;
 }
+
+window.addEventListener('load', registerRaceCategoryStageSelection);
 
 //-->
 </SCRIPT>
@@ -246,7 +250,7 @@ while ($zaznam=mysqli_fetch_array($vysledek))
 	{	// neprihlasen
 		$row[] = ($entry_lock) ? '-':'<INPUT TYPE="text" NAME="kateg['.$u.']" SIZE=5 onfocus="javascript:select_row('.$u.');">';
 		if($is_multi_etapa)
-			$row[] = ($entry_lock) ? '-' : RenderEtapyCell($u, $etap_count, range(1, $etap_count), false);
+			$row[] = ($entry_lock) ? '-' : RenderEtapyCell($u, $etap_count, [], false);
 		if($is_spol_dopr_on||$is_sdil_dopr_on)
 			$row[] = '<INPUT TYPE="checkbox" NAME="transport['.$u.']" onfocus="javascript:select_row('.$u.');" onchange="javascript:update_transport(this,'.$u.');">';
 		if($is_sdil_dopr_on)

--- a/race_regs_all.php
+++ b/race_regs_all.php
@@ -39,6 +39,8 @@ $sub_query = $sc->get_sql_string();
 @$vysledek_z=query_db("SELECT * FROM ".TBL_RACE." WHERE id=$id");
 $zaznam_z = mysqli_fetch_array($vysledek_z);
 $sync_status_column = CreateRaceSyncStatusColumn($zaznam_z);
+$is_multi_etapa = IsMultiEtapaRace($zaznam_z);
+$etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
 
 DrawPageSubTitle('Vybraný závod');
 
@@ -119,7 +121,7 @@ else
 
 $sub_query2 = (IsLoggedRegistrator() || IsLoggedManager()) ? '' : ' AND '.TBL_USER.'.chief_id = '.$usr->user_id.' OR '.TBL_USER.'.id = '.$usr->user_id;
 
-$query = 'SELECT '.TBL_USER.'.id, prijmeni, jmeno, reg, datum, kat, pozn, pozn_in, termin, entry_locked, '.TBL_ZAVXUS.'.transport, '.TBL_ZAVXUS.'.sedadel, '.TBL_ZAVXUS.'.ubytovani, '.TBL_ZAVXUS.'.sync_status FROM '.TBL_USER.' LEFT JOIN '.TBL_ZAVXUS.' ON '.TBL_USER.'.id = '.TBL_ZAVXUS.'.id_user AND '.TBL_ZAVXUS.'.id_zavod='.$id.' WHERE '.TBL_USER.'.hidden = 0'.$sub_query2.$sub_query;
+$query = 'SELECT '.TBL_USER.'.id, prijmeni, jmeno, reg, datum, kat, pozn, pozn_in, termin, entry_locked, '.TBL_ZAVXUS.'.transport, '.TBL_ZAVXUS.'.sedadel, '.TBL_ZAVXUS.'.ubytovani, '.TBL_ZAVXUS.'.etapy, '.TBL_ZAVXUS.'.sync_status FROM '.TBL_USER.' LEFT JOIN '.TBL_ZAVXUS.' ON '.TBL_USER.'.id = '.TBL_ZAVXUS.'.id_user AND '.TBL_ZAVXUS.'.id_zavod='.$id.' WHERE '.TBL_USER.'.hidden = 0'.$sub_query2.$sub_query;
 
 @$vysledek=query_db($query);
 
@@ -132,6 +134,18 @@ $is_spol_dopr_on = ($zaznam_z["transport"]==1);
 $is_sdil_dopr_on = ($zaznam_z["transport"]==3);
 $is_spol_ubyt_on = ($zaznam_z["ubytovani"]==1);
 
+function RenderEtapyCell($u, $etapCount, array $selected, $disabled)
+{
+	$disabledAttr = $disabled ? ' disabled readonly' : '';
+	$html = '';
+	for ($e = 1; $e <= $etapCount; $e++)
+	{
+		$checked = in_array($e, $selected) ? ' checked' : '';
+		$html .= '<label><input type="checkbox" name="etapy['.$u.'][]" value="'.$e.'"'.$checked.$disabledAttr.' onfocus="javascript:select_row('.$u.');"> '.$e.'</label> ';
+	}
+	return $html;
+}
+
 $data_tbl = new html_table_mc();
 $col = 0;
 $data_tbl->set_header_col($col++,'Poř.č.',ALIGN_CENTER);
@@ -140,6 +154,8 @@ $data_tbl->set_header_col($col++,'Příjmení',ALIGN_LEFT);
 $data_tbl->set_header_col($col++,'Jméno',ALIGN_LEFT);
 $data_tbl->set_header_col($col++,'Věk',ALIGN_CENTER);
 $data_tbl->set_header_col($col++,'Kategorie',ALIGN_CENTER);
+if($is_multi_etapa)
+	$data_tbl->set_header_col($col++,'Etapy',ALIGN_CENTER);
 if($is_spol_dopr_on||$is_sdil_dopr_on )
 	$data_tbl->set_header_col_with_help($col++,'SD',ALIGN_CENTER,($is_spol_dopr_on?'Společná':'Sdílená').' doprava');
 if($is_sdil_dopr_on)
@@ -187,6 +203,8 @@ while ($zaznam=mysqli_fetch_array($vysledek))
 		if($zaznam['termin'] == $termin || $is_termin_edit_on || $zaznam_z['prihlasky'] == 1)
 		{	// aktualni termin nebo povelena komplet editace
 			$row[] = ($entry_lock) ? $zaznam['kat']:'<INPUT TYPE="text" NAME="kateg['.$u.']" SIZE=5 value="'.$zaznam['kat'].'" onfocus="javascript:select_row('.$u.');">';
+			if($is_multi_etapa)
+				$row[] = RenderEtapyCell($u, $etap_count, ParseEtapyString($zaznam['etapy'] ?? null), $entry_lock);
 			if($is_spol_dopr_on||$is_sdil_dopr_on) {
 				$nextRow = '<INPUT TYPE="checkbox" NAME="transport['.$u.']" '.$trans.' onfocus="javascri]pt:select_row('.$u.');"';
 				if($is_sdil_dopr_on) 
@@ -208,6 +226,8 @@ while ($zaznam=mysqli_fetch_array($vysledek))
 		else
 		{
 			$row[] = ($entry_lock) ? $zaznam['kat']:'<INPUT TYPE="text" NAME="kateg['.$u.']" SIZE=5 value="'.$zaznam['kat'].'" onfocus="javascript:select_row('.$u.');" disabled readonly>';
+			if($is_multi_etapa)
+				$row[] = RenderEtapyCell($u, $etap_count, ParseEtapyString($zaznam['etapy'] ?? null), true);
 			if($is_spol_dopr_on||$is_sdil_dopr_on)
 				$row[] = '<INPUT TYPE="checkbox" NAME="transport['.$u.']" '.$trans.' onfocus="javascript:select_row('.$u.');" disabled readonly>';
 			if($is_sdil_dopr_on)
@@ -225,6 +245,8 @@ while ($zaznam=mysqli_fetch_array($vysledek))
 	else
 	{	// neprihlasen
 		$row[] = ($entry_lock) ? '-':'<INPUT TYPE="text" NAME="kateg['.$u.']" SIZE=5 onfocus="javascript:select_row('.$u.');">';
+		if($is_multi_etapa)
+			$row[] = ($entry_lock) ? '-' : RenderEtapyCell($u, $etap_count, range(1, $etap_count), false);
 		if($is_spol_dopr_on||$is_sdil_dopr_on)
 			$row[] = '<INPUT TYPE="checkbox" NAME="transport['.$u.']" onfocus="javascript:select_row('.$u.');" onchange="javascript:update_transport(this,'.$u.');">';
 		if($is_sdil_dopr_on)

--- a/race_regs_all_exc.php
+++ b/race_regs_all_exc.php
@@ -48,6 +48,10 @@ $termin = raceterms::GetCurr4RegTerm($zaznam_z);
 $has_ext_id = !empty($zaznam_z['ext_id']);
 $sync_queue = [];
 
+// vicedenni (etapovy) zavod - hromadna prihlaska automaticky zaridi vsechny etapy
+$is_multi_etapa = IsMultiEtapaRace($zaznam_z);
+$etapy_sql = $is_multi_etapa ? "'".AllEtapyString($zaznam_z['etap'])."'" : 'NULL';
+
 while ($zaznamZ=mysqli_fetch_array($vysledek))
 {
 	$user=$zaznamZ["id"];
@@ -120,7 +124,7 @@ while ($zaznamZ=mysqli_fetch_array($vysledek))
 					$sync_status_update = ", sync_status='PENDING_UPDATE'";
 				}
 
-				$result=query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kat', pozn='$poz', pozn_in='$poz2', termin='$cterm', transport=$trans, sedadel=$sedl, ubytovani=$ubyt".$sync_status_update." WHERE id_zavod = '$id' AND id_user = '$user'")
+				$result=query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kat', pozn='$poz', pozn_in='$poz2', termin='$cterm', transport=$trans, sedadel=$sedl, ubytovani=$ubyt, etapy=".$etapy_sql.$sync_status_update." WHERE id_zavod = '$id' AND id_user = '$user'")
 					or die("Chyba při provádění dotazu do databáze.");
 				if ($result == FALSE)
 					die ("Nepodařilo se změnit přihlášku člena.");
@@ -142,7 +146,7 @@ while ($zaznamZ=mysqli_fetch_array($vysledek))
 			
 				$sync_status = $has_ext_id ? 'PENDING_CREATE' : 'LOCAL_ONLY';
 
-				$result=query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in, termin, transport, sedadel,ubytovani, sync_status) VALUES ('$user','$id','$kat','$poz','$poz2','$cterm',$trans,$sedl,$ubyt,'$sync_status')")
+				$result=query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in, termin, transport, sedadel,ubytovani, etapy, sync_status) VALUES ('$user','$id','$kat','$poz','$poz2','$cterm',$trans,$sedl,$ubyt,".$etapy_sql.",'$sync_status')")
 					or die("Chyba při provádění dotazu do databáze.");
 				if ($result == FALSE)
 					die ("Nepodařilo se změnit přihlášku člena.");
@@ -208,9 +212,10 @@ if ($has_ext_id && count($sync_queue) > 0) {
 							$prev_transport = (int)$sq['previous_state']['transport'];
 							$prev_sedadel = (!isset($sq['previous_state']['sedadel']) || $sq['previous_state']['sedadel'] === null) ? 'null' : (int)$sq['previous_state']['sedadel'];
 							$prev_ubytovani = (!isset($sq['previous_state']['ubytovani']) || $sq['previous_state']['ubytovani'] === null) ? 'null' : (int)$sq['previous_state']['ubytovani'];
+							$prev_etapy = empty($sq['previous_state']['etapy']) ? 'NULL' : "'".correct_sql_string($sq['previous_state']['etapy'])."'";
 							$prev_sync_status = correct_sql_string($sq['previous_state']['sync_status']);
 
-							query_db("UPDATE ".TBL_ZAVXUS." SET kat='$prev_kat', pozn='$prev_pozn', pozn_in='$prev_pozn_in', termin='$prev_termin', transport=$prev_transport, sedadel=$prev_sedadel, ubytovani=$prev_ubytovani, sync_status='$prev_sync_status' WHERE id='{$sq['id']}'");
+							query_db("UPDATE ".TBL_ZAVXUS." SET kat='$prev_kat', pozn='$prev_pozn', pozn_in='$prev_pozn_in', termin='$prev_termin', transport=$prev_transport, sedadel=$prev_sedadel, ubytovani=$prev_ubytovani, etapy=$prev_etapy, sync_status='$prev_sync_status' WHERE id='{$sq['id']}'");
 						}
 					}
 				}

--- a/race_regs_all_exc.php
+++ b/race_regs_all_exc.php
@@ -9,6 +9,7 @@ $transport = $_REQUEST['transport'] ?? null;
 $sedadel = $_REQUEST['sedadel'] ?? null;
 $ubytovani = $_REQUEST['ubytovani'] ?? null;
 $term = $_REQUEST['term'] ?? null;
+$etapy = $_REQUEST['etapy'] ?? [];
 
 //TBD: podpora entry_locked
 
@@ -48,9 +49,10 @@ $termin = raceterms::GetCurr4RegTerm($zaznam_z);
 $has_ext_id = !empty($zaznam_z['ext_id']);
 $sync_queue = [];
 
-// vicedenni (etapovy) zavod - hromadna prihlaska automaticky zaridi vsechny etapy
+// vicedenni (etapovy) zavod - vyber etap se preberě ze zaskrtavatek, pokud nejsou
+// vyplnene (napr. radek zamceny/needitovatelny), zustava puvodni vyber zachovan
 $is_multi_etapa = IsMultiEtapaRace($zaznam_z);
-$etapy_sql = $is_multi_etapa ? "'".AllEtapyString($zaznam_z['etap'])."'" : 'NULL';
+$etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
 
 while ($zaznamZ=mysqli_fetch_array($vysledek))
 {
@@ -93,6 +95,15 @@ while ($zaznamZ=mysqli_fetch_array($vysledek))
 			$q_zavxus = query_db("SELECT * FROM ".TBL_ZAVXUS." WHERE id_zavod='$id' AND id_user='$user'");
 			$row_zx = mysqli_fetch_assoc($q_zavxus);
 			$zx_id = $row_zx['id'] ?? 0;
+
+			if ($is_multi_etapa) {
+				$submittedEtapy = array_values(array_intersect(range(1, $etap_count), array_map('intval', (array)($etapy[$user] ?? []))));
+				$etapy_sql = !empty($submittedEtapy)
+					? "'".BuildEtapyString($submittedEtapy)."'"
+					: (!empty($row_zx['etapy']) ? "'".correct_sql_string($row_zx['etapy'])."'" : 'NULL');
+			} else {
+				$etapy_sql = 'NULL';
+			}
 
 			if ($kat == "")
 			{	// del
@@ -143,7 +154,14 @@ while ($zaznamZ=mysqli_fetch_array($vysledek))
 				$poz=correct_sql_string($poz);
 				$poz2=correct_sql_string($poz2);
 				$cterm=correct_sql_string($cterm);
-			
+
+				if ($is_multi_etapa) {
+					$submittedEtapy = array_values(array_intersect(range(1, $etap_count), array_map('intval', (array)($etapy[$user] ?? []))));
+					$etapy_sql = !empty($submittedEtapy) ? "'".BuildEtapyString($submittedEtapy)."'" : "'".AllEtapyString($etap_count)."'";
+				} else {
+					$etapy_sql = 'NULL';
+				}
+
 				$sync_status = $has_ext_id ? 'PENDING_CREATE' : 'LOCAL_ONLY';
 
 				$result=query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in, termin, transport, sedadel,ubytovani, etapy, sync_status) VALUES ('$user','$id','$kat','$poz','$poz2','$cterm',$trans,$sedl,$ubyt,".$etapy_sql.",'$sync_status')")

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -40,6 +40,7 @@ These files are not part of the PHP runtime and must not be deployed to the prod
   - `TEST_USERS.member` = `tnov_5`
   - `TEST_USERS.accountant` = `tnov_6`
 - Shared reusable member fixtures keyed by registration id live in `tests/playwright/constants/members.js`
+- The test-only `member-7203-setup` project ensures the shared `7203` fixture before parallel workflow projects start and fails if that registration is already duplicated
 - Shared group IDs, route maps, and per-role login expectations live in `tests/playwright/constants/routes.js`
 - Prefer importing `TEST_USERS` in specs instead of hardcoding seeded usernames
 - Reusable workflow helpers live under `tests/playwright/helpers/`

--- a/tests/playwright/helpers/app-actions.js
+++ b/tests/playwright/helpers/app-actions.js
@@ -117,11 +117,12 @@ function getMemberDirectoryPath(role = 'clubAdmin') {
   }
 }
 
-async function findClubMemberByReg(page, reg, role) {
+async function findClubMembersByReg(page, reg, role) {
   await page.goto(getMemberDirectoryPath(role));
 
   return page.evaluate((formattedReg) => {
     const rows = Array.from(document.querySelectorAll('table.ctmc tbody tr'));
+    const matches = [];
 
     for (const row of rows) {
       const cells = row.querySelectorAll('td');
@@ -135,14 +136,29 @@ async function findClubMemberByReg(page, reg, role) {
       }
 
       const editLink = row.querySelector('a[href*="./user_edit.php"], a[href*="user_edit.php"]');
-      return {
+      matches.push({
         reg: regText,
         editPath: editLink ? editLink.getAttribute('href') : null,
-      };
+      });
     }
 
-    return null;
+    return matches;
   }, formatClubReg(reg));
+}
+
+async function findClubMemberByReg(page, reg, role, options = {}) {
+  const matches = await findClubMembersByReg(page, reg, role);
+
+  if (options.requireUnique && matches.length > 1) {
+    const userIds = matches.map((member) => (
+      getUserIdFromEditPath(member.editPath) || 'unknown'
+    ));
+    throw new Error(
+      `Expected one club member with reg ${formatClubReg(reg)}, found ${matches.length} (user IDs: ${userIds.join(', ')})`
+    );
+  }
+
+  return matches[0] || null;
 }
 
 async function getFinanceDirectoryEntryByReg(page, reg, options = {}) {
@@ -228,7 +244,8 @@ async function getFinanceDirectoryEntryByReg(page, reg, options = {}) {
 async function ensureClubMember(page, overrides = {}) {
   const role = overrides.role || 'clubAdmin';
   const financePage = overrides.financePage;
-  const existingMember = await findClubMemberByReg(page, overrides.reg, role);
+  const lookupOptions = { requireUnique: Boolean(overrides.requireUnique) };
+  const existingMember = await findClubMemberByReg(page, overrides.reg, role, lookupOptions);
 
   if (existingMember) {
     const existingUserId = getUserIdFromEditPath(existingMember.editPath);
@@ -272,7 +289,7 @@ async function ensureClubMember(page, overrides = {}) {
 
   ensureHtmlSubmission(result, 'Ensure club member');
 
-  const createdMember = await findClubMemberByReg(page, overrides.reg, role);
+  const createdMember = await findClubMemberByReg(page, overrides.reg, role, lookupOptions);
   if (!createdMember) {
     throw new Error(`Club member with reg ${formatClubReg(overrides.reg)} was not found after ensure`);
   }
@@ -294,6 +311,7 @@ async function ensureClubMember(page, overrides = {}) {
 async function ensureClubMembers(page, registrationIds, options = {}) {
   const role = options.role || 'clubAdmin';
   const financePage = options.financePage;
+  const requireUnique = Boolean(options.requireUnique);
   const ensuredMembers = [];
 
   for (const registrationId of registrationIds) {
@@ -306,6 +324,7 @@ async function ensureClubMembers(page, registrationIds, options = {}) {
     const member = await ensureClubMember(page, {
       role,
       financePage,
+      requireUnique,
       ...fixture,
     });
 

--- a/tests/playwright/helpers/oris-mock.js
+++ b/tests/playwright/helpers/oris-mock.js
@@ -96,6 +96,10 @@ async function getOrisMockRaceEntries(request, eventId) {
   return getJson(request, `/races/${eventId}/entries`);
 }
 
+async function getOrisMockParticipants(request) {
+  return getJson(request, '/participants');
+}
+
 async function deleteOrisMockRaceEntry(request, eventId, entryId) {
   return deleteJson(request, `/races/${eventId}/entries/${entryId}`);
 }
@@ -139,6 +143,7 @@ module.exports = {
   deleteOrisMockRaceEntry,
   getOrisApiEvent,
   getOrisApiEventEntries,
+  getOrisMockParticipants,
   getOrisMockRaceEntries,
   resetOrisMock,
   setOrisMockSettings,

--- a/tests/playwright/member-7203.setup.js
+++ b/tests/playwright/member-7203.setup.js
@@ -1,0 +1,13 @@
+const { test, expect } = require('@playwright/test');
+const { loginAs } = require('./helpers/browser');
+const { ensureClubMembers } = require('./helpers/app-actions');
+
+test('ensure shared member 7203 exists exactly once', async ({ page }) => {
+  await loginAs(page, 'clubAdmin');
+
+  const [member] = await ensureClubMembers(page, ['7203'], {
+    requireUnique: true,
+  });
+
+  expect(member.userId).toBeTruthy();
+});

--- a/tests/playwright/workflows/multiuser-race-flow.spec.js
+++ b/tests/playwright/workflows/multiuser-race-flow.spec.js
@@ -58,7 +58,8 @@ test.describe('Multi-User Race Workflow', () => {
     state.run = createWorkflowRun('multi-user-race-flow');
 
     const today = new Date();
-    const entryDate = formatCzDate(addUtcDays(today, 7));
+    const entryDate1 = formatCzDate(addUtcDays(today, -2));
+    const entryDate2 = formatCzDate(addUtcDays(today, 7));
     const raceDate = formatCzDate(addUtcDays(today, 14));
 
     state.managerRaceUser = getTestMemberFixture('8511');
@@ -118,7 +119,8 @@ test.describe('Multi-User Race Workflow', () => {
     state.race = await createRace(registrarPage, request, {
       name: state.labels.raceName,
       note: state.labels.raceNoteInitial,
-      entryDate1: entryDate,
+      entryDate1: entryDate1,
+      entryDate2: entryDate2,
       date: raceDate,
       eventType: 'T',
       transport: '3',

--- a/tests/playwright/workflows/oris-mockup-multistage-race-flow.spec.js
+++ b/tests/playwright/workflows/oris-mockup-multistage-race-flow.spec.js
@@ -1,0 +1,292 @@
+const { test, expect } = require('@playwright/test');
+const { TEST_USERS } = require('../constants/users');
+const {
+  getCurrentUser,
+  loginViaApi,
+} = require('../helpers/api');
+const {
+  loginAs,
+  openPopup,
+} = require('../helpers/browser');
+const {
+  ensureClubMembers,
+} = require('../helpers/app-actions');
+const {
+  createOrisMockRace,
+  createOrisMockUser,
+  getOrisApiEvent,
+  getOrisMockParticipants,
+} = require('../helpers/oris-mock');
+const {
+  ensureOrisRace,
+} = require('../helpers/oris-race-workflow');
+const {
+  addUtcDays,
+  createWorkflowRun,
+} = require('../helpers/workflow-runtime');
+
+function formatOrisDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatDisplayedCzDate(date) {
+  return `${date.getUTCDate()}.${date.getUTCMonth() + 1}.${date.getUTCFullYear()}`;
+}
+
+function stageCheckbox(popup, stage) {
+  return popup.locator(`input[name="etapy[]"][value="${stage}"]`);
+}
+
+function raceListRow(page, raceName) {
+  return page
+    .getByRole('link', { name: raceName, exact: true })
+    .locator('xpath=ancestor::tr[1]');
+}
+
+function bulkCategoryInput(popup, reg) {
+  return popup
+    .locator('td')
+    .filter({ hasText: new RegExp(`^${reg}$`) })
+    .first()
+    .locator('xpath=ancestor::tr[1]')
+    .locator('input[name^="kateg["]');
+}
+
+async function saveRegistrationAndExpectClose(popup) {
+  await Promise.all([
+    popup.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+    popup.locator('form[name="form1"] input[type="submit"]').click(),
+  ]);
+  await popup.close();
+  expect(popup.isClosed()).toBe(true);
+}
+
+test.describe('ORIS Mockup Multistage Race Workflow', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const state = {};
+
+  test.beforeAll(async ({ browser, request }) => {
+    state.run = createWorkflowRun('oris-mockup-multistage-race-flow');
+    state.memberToken = await loginViaApi(request, TEST_USERS.member);
+    state.memberUser = await getCurrentUser(request, state.memberToken);
+
+    await createOrisMockUser(request, {
+      userId: '29952',
+      clubUserId: '39952',
+      regNo: 'ZBM9952',
+      firstName: state.memberUser.name || 'Zuzana',
+      lastName: state.memberUser.surname || 'Novakova',
+      si: state.memberUser.chip_number || '1341431',
+      licence: 'C',
+    });
+    await createOrisMockUser(request, {
+      userId: '28511',
+      clubUserId: '38511',
+      regNo: 'ZBM8511',
+      firstName: 'Jan',
+      lastName: 'Drabek',
+      si: '49690',
+      licence: 'C',
+    });
+    await createOrisMockUser(request, {
+      userId: '54452',
+      clubUserId: '37517',
+      regNo: 'ZBM7203',
+      firstName: 'Radim',
+      lastName: 'Cenek',
+      si: '2181929',
+      licence: 'C',
+    });
+
+    const clubAdminContext = await browser.newContext();
+    const clubAdminPage = await clubAdminContext.newPage();
+    try {
+      await loginAs(clubAdminPage, 'clubAdmin');
+      await ensureClubMembers(clubAdminPage, ['8511', '7203']);
+    } finally {
+      await clubAdminContext.close();
+    }
+
+    const firstRaceDate = addUtcDays(new Date(), 14);
+    state.expectedRaceDate = formatDisplayedCzDate(firstRaceDate);
+    const classes = [{ Name: 'H35', Fee: 150 }];
+    const thirdStage = await createOrisMockRace(request, {
+      name: `PW multistage ${state.run.runId} - stage 3`,
+      date: formatOrisDate(addUtcDays(firstRaceDate, 2)),
+      classes,
+    });
+    const secondStage = await createOrisMockRace(request, {
+      name: `PW multistage ${state.run.runId} - stage 2`,
+      date: formatOrisDate(addUtcDays(firstRaceDate, 1)),
+      classes,
+    });
+    state.secondStageId = String(secondStage.race.ID);
+    state.thirdStageId = String(thirdStage.race.ID);
+
+    state.mockRace = await createOrisMockRace(request, {
+      name: `PW multistage ${state.run.runId}`,
+      date: formatOrisDate(firstRaceDate),
+      stages: 3,
+      stage2: state.secondStageId,
+      stage3: state.thirdStageId,
+      classes,
+    });
+    state.orisId = String(state.mockRace.race.ID);
+  });
+
+  test('registrar imports the linked three-stage mock race', async ({ page, request }) => {
+    await loginAs(page, 'registrar');
+    state.race = await ensureOrisRace(page, state.orisId);
+
+    const event = await getOrisApiEvent(request, state.orisId);
+    const secondStage = await getOrisApiEvent(request, state.secondStageId);
+    const thirdStage = await getOrisApiEvent(request, state.thirdStageId);
+    expect(event.Stages).toBe(3);
+    expect(event.Stage1).toBe(state.orisId);
+    expect(event.Stage2).toBe(state.secondStageId);
+    expect(event.Stage3).toBe(state.thirdStageId);
+    expect(Date.parse(`${secondStage.Date}T00:00:00Z`) - Date.parse(`${event.Date}T00:00:00Z`))
+      .toBe(24 * 60 * 60 * 1000);
+    expect(Date.parse(`${thirdStage.Date}T00:00:00Z`) - Date.parse(`${secondStage.Date}T00:00:00Z`))
+      .toBe(24 * 60 * 60 * 1000);
+    expect(state.race.id).toBeTruthy();
+    expect(state.race.date).toBe(state.expectedRaceDate);
+  });
+
+  test('member registers for H35 with stages 1 and 3', async ({ page }) => {
+    await loginAs(page, 'member');
+    await page.goto('./index.php?id=200&subid=2');
+
+    let row = raceListRow(page, state.mockRace.race.Name);
+    await expect(row).toBeVisible();
+    const popup = await openPopup(page, () => row.getByRole('link', { name: 'Přihl.' }).click());
+
+    await expect(stageCheckbox(popup, 1)).toBeChecked();
+    await expect(stageCheckbox(popup, 2)).toBeChecked();
+    await expect(stageCheckbox(popup, 3)).toBeChecked();
+
+    await popup.locator('input[name="kat"]').fill('H35');
+    await stageCheckbox(popup, 2).uncheck();
+    await saveRegistrationAndExpectClose(popup);
+  });
+
+  test('member changes the selected stages to 1 and 2', async ({ page, request }) => {
+    await loginAs(page, 'member');
+    await page.goto('./index.php?id=200&subid=2');
+
+    const row = raceListRow(page, state.mockRace.race.Name);
+    await expect(row.getByRole('link', { name: 'H35' })).toBeVisible();
+    const popup = await openPopup(page, () => row.getByRole('link', { name: 'H35' }).click());
+
+    await expect(stageCheckbox(popup, 1)).toBeChecked();
+    await expect(stageCheckbox(popup, 2)).not.toBeChecked();
+    await expect(stageCheckbox(popup, 3)).toBeChecked();
+
+    await stageCheckbox(popup, 2).check();
+    await stageCheckbox(popup, 3).uncheck();
+    await saveRegistrationAndExpectClose(popup);
+
+    const { participants } = await getOrisMockParticipants(request);
+    const entry = participants.find((participant) => (
+      String(participant.event_id) === state.orisId
+      && String(participant.club_user_id) === '39952'
+    ));
+
+    expect(entry).toBeTruthy();
+    expect(entry.stages).toBe('1,2');
+  });
+
+  test('registrar changes categories for two users with the bulk registration form', async ({ page, request }) => {
+    await loginAs(page, 'registrar');
+    await page.goto('./index.php?id=400&subid=1');
+
+    const row = raceListRow(page, state.mockRace.race.Name);
+    const popup = await openPopup(page, () => (
+      row.getByRole('link', { name: 'P.V', exact: true }).click()
+    ));
+    await expect(popup.getByRole('heading', { name: 'Hromadná přihlášky na závody' })).toBeVisible();
+
+    const firstCategory = bulkCategoryInput(popup, '8511');
+    const secondCategory = bulkCategoryInput(popup, '7203');
+    await firstCategory.fill('H35');
+    await secondCategory.fill('H35');
+    const verificationUrl = new URL(
+      `./race_regs_all.php?gr_id=400&id=${state.race.id}`,
+      page.url()
+    ).toString();
+
+    await Promise.all([
+      popup.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      popup.locator('input[type="submit"][value="Proveď změny"]').click(),
+    ]);
+    await popup.goto(verificationUrl, { waitUntil: 'domcontentloaded' });
+
+    await expect(bulkCategoryInput(popup, '8511')).toHaveValue('H35');
+    await expect(bulkCategoryInput(popup, '7203')).toHaveValue('H35');
+    await popup.close();
+
+    const { participants } = await getOrisMockParticipants(request);
+    const raceParticipants = participants.filter((participant) => (
+      String(participant.event_id) === state.orisId
+    ));
+
+    expect(raceParticipants).toHaveLength(3);
+    expect(raceParticipants).toEqual(expect.arrayContaining([
+      expect.objectContaining({ club_user_id: '39952', stages: '1,2' }),
+      expect.objectContaining({ club_user_id: '38511', stages: '1,2,3' }),
+      expect.objectContaining({ club_user_id: '37517', stages: '1,2,3' }),
+    ]));
+  });
+
+  test('member still has stages 1 and 2 selected after the bulk update', async ({ page }) => {
+    await loginAs(page, 'member');
+    await page.goto('./index.php?id=200&subid=2');
+
+    const row = raceListRow(page, state.mockRace.race.Name);
+    await expect(row.getByRole('link', { name: 'H35' })).toBeVisible();
+    const popup = await openPopup(page, () => row.getByRole('link', { name: 'H35' }).click());
+
+    await expect(stageCheckbox(popup, 1)).toBeChecked();
+    await expect(stageCheckbox(popup, 2)).toBeChecked();
+    await expect(stageCheckbox(popup, 3)).not.toBeChecked();
+    await popup.close();
+  });
+
+  test('member unregisters with the Od. race-list link', async ({ page }) => {
+    await loginAs(page, 'member');
+    await page.goto('./index.php?id=200&subid=2');
+
+    let row = raceListRow(page, state.mockRace.race.Name);
+    await expect(row.getByRole('link', { name: 'H35' })).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    const popupPromise = page.waitForEvent('popup');
+    await row.getByRole('link', { name: 'Od.' }).click();
+    const popup = await popupPromise;
+    await expect.poll(() => popup.isClosed()).toBe(true);
+  });
+
+  test('member sees no category on the unregistered race', async ({ page, request }) => {
+    await loginAs(page, 'member');
+    await page.goto('./index.php?id=200&subid=2');
+
+    const row = raceListRow(page, state.mockRace.race.Name);
+    await expect(row.getByRole('link', { name: 'Přihl.' })).toBeVisible();
+    await expect(row).not.toContainText('H35');
+
+    const { participants } = await getOrisMockParticipants(request);
+    const raceParticipants = participants.filter((participant) => (
+      String(participant.event_id) === state.orisId
+    ));
+
+    expect(raceParticipants).toHaveLength(2);
+    expect(raceParticipants).toEqual(expect.arrayContaining([
+      expect.objectContaining({ club_user_id: '38511', stages: '1,2,3' }),
+      expect.objectContaining({ club_user_id: '37517', stages: '1,2,3' }),
+    ]));
+    expect(raceParticipants).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ club_user_id: '39952' }),
+    ]));
+  });
+});

--- a/tests/playwright/workflows/oris-mockup-multistage-race-flow.spec.js
+++ b/tests/playwright/workflows/oris-mockup-multistage-race-flow.spec.js
@@ -10,6 +10,7 @@ const {
 } = require('../helpers/browser');
 const {
   ensureClubMembers,
+  submitManagedRaceRegistration,
 } = require('../helpers/app-actions');
 const {
   createOrisMockRace,
@@ -43,13 +44,21 @@ function raceListRow(page, raceName) {
     .locator('xpath=ancestor::tr[1]');
 }
 
-function bulkCategoryInput(popup, reg) {
+function bulkRegistrationRow(popup, reg) {
   return popup
     .locator('td')
     .filter({ hasText: new RegExp(`^${reg}$`) })
     .first()
-    .locator('xpath=ancestor::tr[1]')
-    .locator('input[name^="kateg["]');
+    .locator('xpath=ancestor::tr[1]');
+}
+
+function bulkCategoryInput(popup, reg) {
+  return bulkRegistrationRow(popup, reg).locator('input[name^="kateg["]');
+}
+
+function bulkStageCheckbox(popup, reg, stage) {
+  return bulkRegistrationRow(popup, reg)
+    .locator(`input[name^="etapy["][value="${stage}"]`);
 }
 
 async function saveRegistrationAndExpectClose(popup) {
@@ -209,8 +218,27 @@ test.describe('ORIS Mockup Multistage Race Workflow', () => {
 
     const firstCategory = bulkCategoryInput(popup, '8511');
     const secondCategory = bulkCategoryInput(popup, '7203');
+
+    for (const stage of [1, 2, 3]) {
+      await expect(bulkStageCheckbox(popup, '8511', stage)).not.toBeChecked();
+      await expect(bulkStageCheckbox(popup, '7203', stage)).not.toBeChecked();
+    }
+
+    await expect(bulkStageCheckbox(popup, '9952', 1)).toBeChecked();
+    await expect(bulkStageCheckbox(popup, '9952', 2)).toBeChecked();
+    await expect(bulkStageCheckbox(popup, '9952', 3)).not.toBeChecked();
+
     await firstCategory.fill('H35');
     await secondCategory.fill('H35');
+
+    for (const stage of [1, 2, 3]) {
+      await expect(bulkStageCheckbox(popup, '8511', stage)).toBeChecked();
+      await expect(bulkStageCheckbox(popup, '7203', stage)).toBeChecked();
+    }
+
+    await bulkStageCheckbox(popup, '8511', 2).uncheck();
+    await bulkStageCheckbox(popup, '8511', 3).uncheck();
+
     const verificationUrl = new URL(
       `./race_regs_all.php?gr_id=400&id=${state.race.id}`,
       page.url()
@@ -224,6 +252,9 @@ test.describe('ORIS Mockup Multistage Race Workflow', () => {
 
     await expect(bulkCategoryInput(popup, '8511')).toHaveValue('H35');
     await expect(bulkCategoryInput(popup, '7203')).toHaveValue('H35');
+    await expect(bulkStageCheckbox(popup, '8511', 1)).toBeChecked();
+    await expect(bulkStageCheckbox(popup, '8511', 2)).not.toBeChecked();
+    await expect(bulkStageCheckbox(popup, '8511', 3)).not.toBeChecked();
     await popup.close();
 
     const { participants } = await getOrisMockParticipants(request);
@@ -234,7 +265,7 @@ test.describe('ORIS Mockup Multistage Race Workflow', () => {
     expect(raceParticipants).toHaveLength(3);
     expect(raceParticipants).toEqual(expect.arrayContaining([
       expect.objectContaining({ club_user_id: '39952', stages: '1,2' }),
-      expect.objectContaining({ club_user_id: '38511', stages: '1,2,3' }),
+      expect.objectContaining({ club_user_id: '38511', stages: '1' }),
       expect.objectContaining({ club_user_id: '37517', stages: '1,2,3' }),
     ]));
   });
@@ -282,9 +313,63 @@ test.describe('ORIS Mockup Multistage Race Workflow', () => {
 
     expect(raceParticipants).toHaveLength(2);
     expect(raceParticipants).toEqual(expect.arrayContaining([
-      expect.objectContaining({ club_user_id: '38511', stages: '1,2,3' }),
+      expect.objectContaining({ club_user_id: '38511', stages: '1' }),
       expect.objectContaining({ club_user_id: '37517', stages: '1,2,3' }),
     ]));
+    expect(raceParticipants).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ club_user_id: '39952' }),
+    ]));
+  });
+
+  test('small manager bulk-adds the removed member and removes them with single edit', async ({ page, request }) => {
+    await loginAs(page, 'smallManager');
+
+    const bulkUrl = `./race_regs_all.php?gr_id=600&id=${state.race.id}`;
+    await page.goto(bulkUrl);
+
+    const category = bulkCategoryInput(page, '9952');
+    await expect(category).toHaveValue('');
+    for (const stage of [1, 2, 3]) {
+      await expect(bulkStageCheckbox(page, '9952', stage)).not.toBeChecked();
+    }
+
+    await category.fill('H35');
+    for (const stage of [1, 2, 3]) {
+      await expect(bulkStageCheckbox(page, '9952', stage)).toBeChecked();
+    }
+
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      page.locator('input[type="submit"][value="Proveď změny"]').click(),
+    ]);
+
+    await expect(bulkCategoryInput(page, '9952')).toHaveValue('H35');
+
+    const singleEditUrl = `./race_regs_1.php?gr_id=600&id=${state.race.id}&show_ed=1`;
+    await page.goto(singleEditUrl);
+
+    const memberOption = page.locator(
+      `select[name="user_id"] option[value="${state.memberUser.user_id}"]`
+    );
+    await expect(memberOption).toContainText('[9952]');
+    await page.locator('select[name="user_id"]').selectOption(String(state.memberUser.user_id));
+
+    await expect(page.locator('input[name="kateg"]')).toHaveValue('H35');
+    for (const stage of [1, 2, 3]) {
+      await expect(stageCheckbox(page, stage)).toBeChecked();
+    }
+
+    await submitManagedRaceRegistration(page, state.race.id, {
+      user_id: String(state.memberUser.user_id),
+      kateg: '',
+    });
+
+    const { participants } = await getOrisMockParticipants(request);
+    const raceParticipants = participants.filter((participant) => (
+      String(participant.event_id) === state.orisId
+    ));
+
+    expect(raceParticipants).toHaveLength(2);
     expect(raceParticipants).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ club_user_id: '39952' }),
     ]));

--- a/tests/playwright/workflows/oris-mockup-multistage-race-flow.spec.js
+++ b/tests/playwright/workflows/oris-mockup-multistage-race-flow.spec.js
@@ -228,6 +228,11 @@ test.describe('ORIS Mockup Multistage Race Workflow', () => {
     await expect(bulkStageCheckbox(popup, '9952', 2)).toBeChecked();
     await expect(bulkStageCheckbox(popup, '9952', 3)).not.toBeChecked();
 
+    await bulkCategoryInput(popup, '9952').fill('H35');
+    await expect(bulkStageCheckbox(popup, '9952', 1)).toBeChecked();
+    await expect(bulkStageCheckbox(popup, '9952', 2)).toBeChecked();
+    await expect(bulkStageCheckbox(popup, '9952', 3)).not.toBeChecked();
+
     await firstCategory.fill('H35');
     await secondCategory.fill('H35');
 

--- a/tools/download_oris_events.sh
+++ b/tools/download_oris_events.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+BASE_URL="https://oris.ceskyorientak.cz/API/"
+FIRST_ID="${FIRST_ID:-1}"
+LAST_ID="${LAST_ID:-10245}"
+OUTPUT_DIR="${OUTPUT_DIR:-oris_events}"
+DELAY="${DELAY:-0.1}"
+FAILURE_LOG="${OUTPUT_DIR}/failed_ids.txt"
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "Error: curl is required." >&2
+    exit 1
+fi
+
+if ! [[ "$FIRST_ID" =~ ^[0-9]+$ && "$LAST_ID" =~ ^[0-9]+$ ]] ||
+   (( FIRST_ID < 1 || FIRST_ID > LAST_ID )); then
+    echo "Error: FIRST_ID and LAST_ID must define a valid positive range." >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+: > "$FAILURE_LOG"
+
+downloaded=0
+skipped=0
+failed=0
+
+for ((id = FIRST_ID; id <= LAST_ID; id++)); do
+    output="${OUTPUT_DIR}/event_${id}.xml"
+    temporary="${output}.part"
+
+    if [[ -s "$output" ]]; then
+        ((skipped++))
+        continue
+    fi
+
+    printf 'Downloading event %d/%d...\r' "$id" "$LAST_ID"
+
+    if curl --silent --show-error --location \
+        --retry 4 --retry-delay 2 --retry-all-errors \
+        --connect-timeout 15 --max-time 60 \
+        --get \
+        --data-urlencode "format=xml" \
+        --data-urlencode "method=getEvent" \
+        --data-urlencode "id=${id}" \
+        --output "$temporary" \
+        "$BASE_URL" &&
+       [[ -s "$temporary" ]]; then
+        mv "$temporary" "$output"
+        ((downloaded++))
+    else
+        rm -f "$temporary"
+        printf '%d\n' "$id" >> "$FAILURE_LOG"
+        ((failed++))
+    fi
+
+    if [[ "$DELAY" != "0" ]]; then
+        sleep "$DELAY"
+    fi
+done
+
+printf '\nDone: %d downloaded, %d already present, %d failed.\n' \
+    "$downloaded" "$skipped" "$failed"
+
+if (( failed == 0 )); then
+    rm -f "$FAILURE_LOG"
+else
+    printf 'Failed IDs are listed in %s\n' "$FAILURE_LOG" >&2
+    exit 1
+fi

--- a/us_race_regon.php
+++ b/us_race_regon.php
@@ -104,7 +104,9 @@ else
 
 $is_multi_etapa = IsMultiEtapaRace($zaznam_z);
 $etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
-$selected_etapy = $new ? range(1, $etap_count) : ParseEtapyString($zaznam_rg['etapy'] ?? null);
+$selected_etapy = ParseEtapyString($zaznam_rg['etapy'] ?? null);
+if ($is_multi_etapa && empty($selected_etapy))
+	$selected_etapy = range(1, $etap_count);
 ?>
 <BR>
 <BUTTON onclick="javascript:close_popup();">Zpět</BUTTON>
@@ -255,6 +257,8 @@ $is_spol_ubyt_on = ($zaznam_z["ubytovani"]==1) && $g_enable_race_accommodation;
 // define table
 $tbl_renderer = RaceRendererFactory::createTable();
 $tbl_renderer->addColumns('id','jmeno','prijmeni','kat');
+if($is_multi_etapa)
+	$tbl_renderer->addColumns('etapy');
 if($is_spol_dopr_on||$is_sdil_dopr_on)
 	$tbl_renderer->addColumns('transport');
 if($is_sdil_dopr_on)

--- a/us_race_regon.php
+++ b/us_race_regon.php
@@ -163,14 +163,13 @@ for ($i=0; $i<count($kategorie); $i++)
 		echo "<button onclick=\"javascript:zmen_kat('".xss_prevent($kategorie[$i])."');return false;\">".xss_prevent($kategorie[$i])."</button>";
 }
 
-echo('<BR><BR>Vybraná kategorie:&nbsp;');
+echo('<BR>Vybraná kategorie:&nbsp;');
 echo('<INPUT TYPE="text" NAME="kat" size=6 value="'.xss_prevent($zaznam_rg['kat']).'">');
 echo("<BR>\n");
 
 if ($is_multi_etapa)
 {
-	echo "<BR>\n";
-	echo 'Vyberte etapy, kterých se chcete zúčastnit:<BR>'."\n";
+	echo 'Etapy:&nbsp;';
 	RenderEtapyCheckboxes($etap_count, $selected_etapy);
 	echo "<BR>\n";
 }

--- a/us_race_regon.php
+++ b/us_race_regon.php
@@ -28,7 +28,7 @@ $id_us = (IsSet($id_us) && is_numeric($id_us)) ? (int)$id_us : 0;
 
 DrawPageTitle('Přihláška na závod');
 
-$query = 'SELECT u.*, z.kat, z.pozn, z.pozn_in, z.termin, z.id_user, z.transport, z.sedadel, z.ubytovani, z.sync_status FROM '.TBL_ZAVXUS.' as z, '.TBL_USER.' as u WHERE z.id_user = u.id AND z.id_zavod='.$id_zav.' ORDER BY z.id ASC';
+$query = 'SELECT u.*, z.kat, z.pozn, z.pozn_in, z.termin, z.id_user, z.transport, z.sedadel, z.ubytovani, z.etapy, z.sync_status FROM '.TBL_ZAVXUS.' as z, '.TBL_USER.' as u WHERE z.id_user = u.id AND z.id_zavod='.$id_zav.' ORDER BY z.id ASC';
 @$vysledek=query_db($query);
 // Fetch all rows into array
 $zaznamy = $vysledek ? mysqli_fetch_all($vysledek, MYSQLI_ASSOC) : [];
@@ -61,8 +61,13 @@ function check_reg(vstup)
 		alert("Musíš zadat kategorii pro přihlášení do závodu.");
 		return false;
 	}
-	else
-		return true;
+	if (vstup.querySelectorAll('input[name="etapy[]"]:checked').length == 0
+		&& vstup.querySelectorAll('input[name="etapy[]"]').length > 0)
+	{
+		alert("Musíš vybrat alespoň jednu etapu.");
+		return false;
+	}
+	return true;
 }
 
 function submit_off()
@@ -94,7 +99,12 @@ else
 	$zaznam_rg['transport'] = null;
 	$zaznam_rg['sedadel'] = null;
 	$zaznam_rg['ubytovani'] = null;
+	$zaznam_rg['etapy'] = null;
 }
+
+$is_multi_etapa = IsMultiEtapaRace($zaznam_z);
+$etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
+$selected_etapy = $new ? range(1, $etap_count) : ParseEtapyString($zaznam_rg['etapy'] ?? null);
 ?>
 <BR>
 <BUTTON onclick="javascript:close_popup();">Zpět</BUTTON>
@@ -156,6 +166,14 @@ for ($i=0; $i<count($kategorie); $i++)
 echo('<BR><BR>Vybraná kategorie:&nbsp;');
 echo('<INPUT TYPE="text" NAME="kat" size=6 value="'.xss_prevent($zaznam_rg['kat']).'">');
 echo("<BR>\n");
+
+if ($is_multi_etapa)
+{
+	echo "<BR>\n";
+	echo 'Vyberte etapy, kterých se chcete zúčastnit:<BR>'."\n";
+	RenderEtapyCheckboxes($etap_count, $selected_etapy);
+	echo "<BR>\n";
+}
 
 if ($g_enable_race_transport || $g_enable_race_accommodation)
 	echo "<BR>\n";

--- a/us_race_regon.php
+++ b/us_race_regon.php
@@ -169,12 +169,10 @@ echo("<BR>\n");
 
 if ($is_multi_etapa)
 {
-	echo 'Etapy:&nbsp;';
+	echo 'Etapy: ';
 	RenderEtapyCheckboxes($etap_count, $selected_etapy);
-	echo "<BR>\n";
 }
-
-if ($g_enable_race_transport || $g_enable_race_accommodation)
+else if ($g_enable_race_transport || $g_enable_race_accommodation)
 	echo "<BR>\n";
 
 if ($g_enable_race_transport)

--- a/us_race_regon.php
+++ b/us_race_regon.php
@@ -171,8 +171,10 @@ if ($is_multi_etapa)
 {
 	echo 'Etapy: ';
 	RenderEtapyCheckboxes($etap_count, $selected_etapy);
+	echo "<BR>\n";
 }
-else if ($g_enable_race_transport || $g_enable_race_accommodation)
+
+if ($g_enable_race_transport || $g_enable_race_accommodation)
 	echo "<BR>\n";
 
 if ($g_enable_race_transport)

--- a/us_race_regon_exc.php
+++ b/us_race_regon_exc.php
@@ -10,6 +10,7 @@ $sedadel = $_REQUEST['sedadel'] ?? null;
 $transport = $_REQUEST['transport'] ?? null;
 $ubytovani = $_REQUEST['ubytovani'] ?? null;
 $novy = $_REQUEST['novy'] ?? null;
+$etapy = $_REQUEST['etapy'] ?? [];
 
 require_once ("./connect.inc.php");
 require_once ("./sess.inc.php");
@@ -44,13 +45,21 @@ if ($kat != '')
 		$pozn=correct_sql_string($pozn);
 		$pozn2=correct_sql_string($pozn2);
 
-		@$vysledek_z=query_db("SELECT datum, vicedenni, prihlasky, prihlasky1, prihlasky2, prihlasky3, prihlasky4, prihlasky5, transport, ext_id FROM ".TBL_RACE." WHERE id=$id_zav");
+		@$vysledek_z=query_db("SELECT datum, vicedenni, etap, prihlasky, prihlasky1, prihlasky2, prihlasky3, prihlasky4, prihlasky5, transport, ext_id FROM ".TBL_RACE." WHERE id=$id_zav");
 		$zaznam_z = mysqli_fetch_array($vysledek_z);
 
 		$termin = raceterms::GetCurr4RegTerm($zaznam_z);
 
-		if ($termin != 0) // not process if invalid termin number
+		$is_multi_etapa = IsMultiEtapaRace($zaznam_z);
+		$etap_count = $is_multi_etapa ? (int)$zaznam_z['etap'] : 0;
+		$selected_etapy = $is_multi_etapa ? array_values(array_intersect(range(1, $etap_count), array_map('intval', (array)$etapy))) : [];
+
+		if ($is_multi_etapa && empty($selected_etapy)) {
+			$sync_error_msg = 'Musíte vybrat alespoň jednu etapu.';
+		}
+		else if ($termin != 0) // not process if invalid termin number
 		{
+			$etapy_sql = $is_multi_etapa ? "'".BuildEtapyString($selected_etapy)."'" : 'NULL';
 			if ( $zaznam_z["transport"] == 3 ) {
 				// shared transport
 				if ( !isset($sedadel) || $sedadel=='' || $sedadel=='null') {
@@ -83,7 +92,7 @@ if ($kat != '')
 					$previous_state = $zaznam;
 					$sync_status_update = ($has_ext_id && $zaznam['sync_status'] !== 'PENDING_CREATE') ? ", sync_status='PENDING_UPDATE'" : "";
 					$sync_action = ($has_ext_id && $zaznam['sync_status'] === 'PENDING_CREATE') ? 'create' : 'update';
-					query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kat', pozn='$pozn', pozn_in='$pozn2', termin='$termin', transport=$transport, sedadel=$sedadel, ubytovani=$ubytovani".$sync_status_update." WHERE id='".$zaznam['id']."'");
+					query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kat', pozn='$pozn', pozn_in='$pozn2', termin='$termin', transport=$transport, sedadel=$sedadel, ubytovani=$ubytovani, etapy=$etapy_sql".$sync_status_update." WHERE id='".$zaznam['id']."'");
 					$inserted_or_updated_id = $zaznam['id'];
 				}
 				else
@@ -91,7 +100,7 @@ if ($kat != '')
 					$is_new_insert = true;
 					$sync_status = $has_ext_id ? 'PENDING_CREATE' : 'LOCAL_ONLY';
 					$sync_action = $has_ext_id ? 'create' : '';
-					$vysledek = query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in, termin, transport, sedadel, ubytovani, sync_status) VALUES ('$id_us','$id_zav','$kat','$pozn','$pozn2','$termin',$transport, $sedadel, $ubytovani, '$sync_status')");	
+					$vysledek = query_db("INSERT INTO ".TBL_ZAVXUS." (id_user, id_zavod, kat, pozn, pozn_in, termin, transport, sedadel, ubytovani, etapy, sync_status) VALUES ('$id_us','$id_zav','$kat','$pozn','$pozn2','$termin',$transport, $sedadel, $ubytovani, $etapy_sql, '$sync_status')");
 					if ($vysledek !== false && mysqli_affected_rows($db_conn) > 0) {
 						$inserted_or_updated_id = mysqli_insert_id($db_conn);
 						query_db("UPDATE ".TBL_RACE." SET prihlasenych = prihlasenych + 1 WHERE id = '$id_zav'");
@@ -106,7 +115,7 @@ if ($kat != '')
 					$previous_state = $zaznam;
 					$sync_status_update = ($has_ext_id && $zaznam['sync_status'] !== 'PENDING_CREATE') ? ", sync_status='PENDING_UPDATE'" : "";
 					$sync_action = ($has_ext_id && $zaznam['sync_status'] === 'PENDING_CREATE') ? 'create' : 'update';
-					query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kat', pozn='$pozn', pozn_in='$pozn2', transport=$transport, sedadel=$sedadel, ubytovani=$ubytovani".$sync_status_update." WHERE id='".$id_z."'");
+					query_db("UPDATE ".TBL_ZAVXUS." SET kat='$kat', pozn='$pozn', pozn_in='$pozn2', transport=$transport, sedadel=$sedadel, ubytovani=$ubytovani, etapy=$etapy_sql".$sync_status_update." WHERE id='".$id_z."'");
 					$inserted_or_updated_id = $id_z;
 				}
 			}
@@ -138,9 +147,10 @@ if ($kat != '')
 								$prev_transport = (int)$previous_state['transport'];
 								$prev_sedadel = (!isset($previous_state['sedadel']) || $previous_state['sedadel'] === null) ? 'null' : (int)$previous_state['sedadel'];
 								$prev_ubytovani = (!isset($previous_state['ubytovani']) || $previous_state['ubytovani'] === null) ? 'null' : (int)$previous_state['ubytovani'];
+								$prev_etapy = empty($previous_state['etapy']) ? 'NULL' : "'".correct_sql_string($previous_state['etapy'])."'";
 								$prev_sync_status = correct_sql_string($previous_state['sync_status']);
 
-								query_db("UPDATE ".TBL_ZAVXUS." SET kat='$prev_kat', pozn='$prev_pozn', pozn_in='$prev_pozn_in', termin='$prev_termin', transport=$prev_transport, sedadel=$prev_sedadel, ubytovani=$prev_ubytovani, sync_status='$prev_sync_status' WHERE id='$inserted_or_updated_id'");
+								query_db("UPDATE ".TBL_ZAVXUS." SET kat='$prev_kat', pozn='$prev_pozn', pozn_in='$prev_pozn_in', termin='$prev_termin', transport=$prev_transport, sedadel=$prev_sedadel, ubytovani=$prev_ubytovani, etapy=$prev_etapy, sync_status='$prev_sync_status' WHERE id='$inserted_or_updated_id'");
 							}
 						}
 					}

--- a/version.inc.php
+++ b/version.inc.php
@@ -6,7 +6,7 @@ define('SYSTEM_AUTORS','Arnošt, Kenia a kolektiv autorů');
 
 function GetCodeVersion()
 {
-	return "v3.5.0.672";
+	return "v3.5.1.673";
 }
 
 function GetCopyright()


### PR DESCRIPTION
## Souhrn

ORIS API (`createEntry`/`updateEntry`) u etapových závodů (vícedenní, více než 1 etapa) vyžaduje parametry `stageX` (X = číslo etapy, hodnota 1/0). Bez nich vrací `Je třeba vybrat alespoň jednu etapu` a přihláška se nikdy nesynchronizuje.

- Přidán sloupec `etapy` do `tst_zavxus` (seznam vybraných etap, např. `1,2`).
- Přihláška odesílaná do ORISu nyní obsahuje `stage1..stageN` podle vybraných etap.
- Formulář pro vlastní přihlášení (`us_race_regon.php`) a jednotlivou registraci registrátorem (`race_regs_1.php`) nabízí výběr etap zaškrtávacími poli (validace „alespoň jedna etapa“ na klientu i serveru).
- Hromadná registrace (`race_regs_all.php`) automaticky vybere všechny etapy bez nutnosti volby.
- `lib/oris_sync.inc.php` u etapového závodu bez vybrané etapy selže rovnou lokálně se srozumitelnou chybou, místo zbytečného volání ORIS API.

## Test plan

- [x] `php -l` na všech upravených souborech
- [x] Playwright e2e suite (`docker-compose.autotest.yml`) — všechny ORIS/etapové scénáře zelené (`oris-public-multistage-race-flow`, `oris-mockup-*`, `multiuser-race-flow`)
- [x] Ruční ověření na produkčních datech po nasazení migrace `_SQL/zmeny_3.5.1.673.sql.php`

Fixes #52