### PR TITLE
fix(oris): Štafetové závody se nesynchronizují do ORISu

### DIFF
--- a/ct_renderer_race.inc.php
+++ b/ct_renderer_race.inc.php
@@ -29,6 +29,12 @@ function CreateRaceSyncStatusColumn($race): ?TableColumn {
         return null;
     }
 
+    // Relay races (zebricek flag 32 = Štafety) always stay local-only (different ORIS
+    // entry process) - hide sync column
+    if (((int)($race['zebricek'] ?? 0) & 32) !== 0) {
+        return null;
+    }
+
     $entry_start_future = false;
     if (is_array($race) && !empty($race['entry_start'])) {
         $entry_start = strtotime($race['entry_start']);

--- a/lib/oris_sync.inc.php
+++ b/lib/oris_sync.inc.php
@@ -86,9 +86,10 @@ function processEntry($row, $action, $service) {
         return;
     }
 
-    // Ignore relays
-    if ($raceRow && isset($raceRow['typ0']) && $raceRow['typ0'] === 'S') {
-        query_db("UPDATE `" . TBL_ZAVXUS . "` SET `sync_status` = 'LOCAL_ONLY' WHERE `id` = " . (int)$id);
+    // Relay races (zebricek flag 32 = Štafety) use a completely different ORIS entry
+    // process (team/leg registration) - always skip, don't persist any sync_status so
+    // the entry resumes normal syncing automatically if the flag is ever corrected.
+    if (((int)($raceRow['zebricek'] ?? 0) & 32) !== 0) {
         return;
     }
 

--- a/mocks/oris/README.md
+++ b/mocks/oris/README.md
@@ -62,6 +62,8 @@ Participant `stages` values are stored as comma-separated, one-based stage index
 ORIS-compatible `createEntry` and `updateEntry` calls accept stage flags such as
 `stage1=1&stage2=0&stage3=1`; a multistage entry must select at least one stage.
 `getEventEntries` exposes the selection as a `Stages` object containing `Stage1`, `Stage2`, and so on.
+For relay races (ORIS level `7`, `ČPŠ` / Czech Relay Cup), `createEntry` always returns the ORIS
+closed-registration response because relay teams and legs use a different ORIS API.
 
 The API log path can be overridden with `ORIS_MOCK_API_LOG_FILE`.
 

--- a/mocks/oris/src/server.ts
+++ b/mocks/oris/src/server.ts
@@ -1055,7 +1055,12 @@ type EntryMutationValidation =
   | { type: 'missingStages' }
   | { type: 'error'; message: string };
 
-function validateEntryMutation(event: JsonObject | null, classId: string, input: JsonObject = {}): EntryMutationValidation {
+function validateEntryMutation(
+  event: JsonObject | null,
+  classId: string,
+  input: JsonObject = {},
+  rejectRelay = false,
+): EntryMutationValidation {
   if (!event) {
     return { type: 'error', message: `Class ${classId || '(missing)'} is not defined for an event.` };
   }
@@ -1063,6 +1068,12 @@ function validateEntryMutation(event: JsonObject | null, classId: string, input:
   const classes = classList(event.Classes);
   if (!classes.some((item) => asString(item.ID) === classId)) {
     return { type: 'error', message: `Class ${classId || '(missing)'} is not defined for event ${asString(event.ID)}.` };
+  }
+
+  // ORIS level 7 (ČPŠ / Czech Relay Cup) maps to the Members relay flag (zebricek & 32).
+  // Relay entries use a team/leg API, so the individual createEntry call is unavailable.
+  if (rejectRelay && idList(event.Level).includes('7')) {
+    return { type: 'closedRegistration' };
   }
 
   if (eventStageCount(event) > 1 && inputStageIndexes(input, event).length === 0) {
@@ -1609,7 +1620,7 @@ async function handleCreateEntry(req: Request, res: Response): Promise<void> {
   try {
     const classId = asString(req.body.class);
     const event = await findEventByClass(classId);
-    const validation = validateEntryMutation(event, classId, req.body);
+    const validation = validateEntryMutation(event, classId, req.body, true);
     if (validation.type !== 'ok') {
       res.json(validation.type === 'closedRegistration'
         ? apiClosedRegistration('createEntry')

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -45,6 +45,7 @@ These files are not part of the PHP runtime and must not be deployed to the prod
 - Prefer importing `TEST_USERS` in specs instead of hardcoding seeded usernames
 - Reusable workflow helpers live under `tests/playwright/helpers/`
 - Shared multi-step workflow specs can live under `tests/playwright/workflows/`
+- `workflows/oris-relay-race-flow.spec.js` covers imported relay races, whose registrations stay local and do not create individual ORIS entries
 - Manual-only suites can use a dedicated Playwright config when they must stay out of the default parallel run
   - Bank connector error checks: `npm run test:e2e:bank-errors`
   - Config: `playwright.bank-errors.config.js`

--- a/tests/playwright/helpers/oris-mock.js
+++ b/tests/playwright/helpers/oris-mock.js
@@ -136,7 +136,23 @@ async function getOrisApiEventEntries(request, eventId) {
   return json.Data;
 }
 
+async function createOrisApiEntry(request, overrides = {}) {
+  const response = await request.post(DEFAULT_ORIS_MOCK_API_URL, {
+    form: {
+      method: 'createEntry',
+      format: 'json',
+      ...overrides,
+    },
+  });
+
+  return {
+    httpStatus: response.status(),
+    body: await response.json(),
+  };
+}
+
 module.exports = {
+  createOrisApiEntry,
   createOrisMockEntry,
   createOrisMockRace,
   createOrisMockUser,

--- a/tests/playwright/oris-mock-relay.spec.js
+++ b/tests/playwright/oris-mock-relay.spec.js
@@ -1,0 +1,77 @@
+const { test, expect } = require('@playwright/test');
+const {
+  createOrisApiEntry,
+  createOrisMockRace,
+  getOrisApiEvent,
+  getOrisMockRaceEntries,
+} = require('./helpers/oris-mock');
+
+const RELAY_RACE_WORKFLOW = {
+  name: 'Relay Race',
+  levelIds: '7',
+  categories: ['H21', 'D21', 'H135', 'D135'],
+  registrations: [
+    { label: 'member', clubUserId: 'relay-member', category: 'D21' },
+    { label: 'participant 8001', clubUserId: '8001', category: 'H135' },
+    { label: 'participant 6107', clubUserId: '6107', category: 'H135' },
+  ],
+};
+
+test.describe(RELAY_RACE_WORKFLOW.name, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('rejects member and participant registrations without mock ORIS users', async ({ request }) => {
+    const mockRace = await createOrisMockRace(request, {
+      name: 'Playwright ORIS mock Relay Race',
+      levelIds: RELAY_RACE_WORKFLOW.levelIds,
+      classes: RELAY_RACE_WORKFLOW.categories.map((Name) => ({ Name, Fee: 150 })),
+    });
+    const eventId = String(mockRace.race.ID);
+    const event = await getOrisApiEvent(request, eventId);
+    const classIds = Object.fromEntries(event.Classes.map((raceClass) => [
+      raceClass.Name,
+      String(raceClass.ID),
+    ]));
+
+    expect(event.Level.ID).toBe(RELAY_RACE_WORKFLOW.levelIds);
+    expect(Object.keys(classIds).sort()).toEqual([...RELAY_RACE_WORKFLOW.categories].sort());
+
+    for (const registration of RELAY_RACE_WORKFLOW.registrations) {
+      const result = await createOrisApiEntry(request, {
+        clubuser: registration.clubUserId,
+        class: classIds[registration.category],
+      });
+
+      expect(result.httpStatus, registration.label).toBe(200);
+      expect(result.body, registration.label).toMatchObject({
+        Method: 'createEntry',
+        Format: 'json',
+        Status: 'Mimo termín přihlášek',
+        Data: [],
+      });
+    }
+
+    expect(await getOrisMockRaceEntries(request, eventId)).toEqual({ entries: [] });
+  });
+
+  test('createEntry accepts a non-relay race while its registration is open', async ({ request }) => {
+    const mockRace = await createOrisMockRace(request, {
+      name: 'Playwright ORIS mock individual race',
+      levelIds: '4',
+      classes: [{ Name: 'H21', Fee: 150 }],
+    });
+    const eventId = String(mockRace.race.ID);
+    const classId = String(mockRace.race.Classes[0].ID);
+
+    const result = await createOrisApiEntry(request, {
+      clubuser: 'individual-test-user',
+      class: classId,
+    });
+
+    expect(result.httpStatus).toBe(200);
+    expect(result.body.Status).toBe('OK');
+    const { entries } = await getOrisMockRaceEntries(request, eventId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].Class.ID).toBe(classId);
+  });
+});

--- a/tests/playwright/workflows/oris-relay-race-flow.spec.js
+++ b/tests/playwright/workflows/oris-relay-race-flow.spec.js
@@ -1,0 +1,260 @@
+const { test, expect } = require('@playwright/test');
+const { TEST_USERS } = require('../constants/users');
+const {
+  getCurrentUser,
+  getRaceDetail,
+  loginViaApi,
+} = require('../helpers/api');
+const {
+  loginAs,
+} = require('../helpers/browser');
+const {
+  submitMemberRaceRegistration,
+  updateRace,
+} = require('../helpers/app-actions');
+const {
+  createOrisMockRace,
+  getOrisApiEvent,
+  getOrisApiEventEntries,
+} = require('../helpers/oris-mock');
+const {
+  ensureOrisRace,
+  ensureRaceParticipants,
+} = require('../helpers/oris-race-workflow');
+const {
+  createWorkflowRun,
+} = require('../helpers/workflow-runtime');
+const {
+  expectFinanceRowValues,
+  financeRow,
+  openRaceFinancePopup,
+} = require('../helpers/race-finance');
+
+const RELAY_RACE_WORKFLOW = {
+  name: 'Relay Race',
+  memberCategory: 'D21',
+  categories: ['H21', 'D21', 'H135', 'D135'],
+  levelIds: '7',
+  rankings: [
+    { id: 1, name: 'Celostátní' },
+    { id: 32, name: 'Štafety' },
+  ],
+  participants: [
+    {
+      '8001': {
+        kateg: 'H21',
+      },
+    },
+    {
+      '6107': {
+        kateg: 'H135',
+      },
+    },
+  ],
+};
+
+function formatSavedRaceDate(date) {
+  return [
+    date.getUTCDate(),
+    date.getUTCMonth() + 1,
+    date.getUTCFullYear(),
+  ].join('.');
+}
+
+test.describe(RELAY_RACE_WORKFLOW.name, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const state = {};
+
+  test.beforeAll(async ({ request }) => {
+    state.run = createWorkflowRun('relay-race-flow');
+    state.memberToken = await loginViaApi(request, TEST_USERS.member);
+    state.memberUser = await getCurrentUser(request, state.memberToken);
+
+    state.mockRace = await createOrisMockRace(request, {
+      name: `Playwright ORIS mock relay ${state.run.runId}`,
+      place: 'Playwright relay arena',
+      levelIds: RELAY_RACE_WORKFLOW.levelIds,
+      classes: RELAY_RACE_WORKFLOW.categories.map((Name) => ({ Name, Fee: 150 })),
+    });
+    state.orisId = String(state.mockRace.race.ID);
+  });
+
+  test('registrar can load the mockup relay race into members', async ({ page, request }) => {
+    await loginAs(page, 'registrar');
+
+    state.race = await ensureOrisRace(page, state.orisId);
+    const orisEvent = await getOrisApiEvent(request, state.orisId);
+    const detail = await getRaceDetail(request, state.race.id);
+
+    expect(Number(state.race.extId)).toBeGreaterThanOrEqual(25000);
+    expect(Number(state.race.extId)).toBeLessThanOrEqual(999999);
+    expect(state.race.extId).toBe(state.orisId);
+    expect(state.race.name).toBe(state.mockRace.race.Name);
+    expect(state.race.id).toBeTruthy();
+    expect(orisEvent.Level.ID).toBe(RELAY_RACE_WORKFLOW.levelIds);
+    expect(orisEvent.Classes.map((raceClass) => raceClass.Name).sort())
+      .toEqual([...RELAY_RACE_WORKFLOW.categories].sort());
+    expect(detail.categories.sort()).toEqual([...RELAY_RACE_WORKFLOW.categories].sort());
+    expect(RELAY_RACE_WORKFLOW.rankings.reduce((flags, ranking) => flags | ranking.id, 0)).toBe(33);
+    expect(detail.rankings.sort())
+      .toEqual(RELAY_RACE_WORKFLOW.rankings.map((ranking) => ranking.name).sort());
+  });
+
+  test('registrar can ensure the configured participants locally', async ({ page, request }) => {
+    await loginAs(page, 'registrar');
+
+    if (!state.race) {
+      state.race = await ensureOrisRace(page, state.orisId);
+    }
+
+    state.participants = await ensureRaceParticipants(
+      page,
+      state.race.id,
+      RELAY_RACE_WORKFLOW.participants
+    );
+
+    expect(state.participants['8001']).toBeTruthy();
+    expect(state.participants['6107']).toBeTruthy();
+    expect(await getOrisApiEventEntries(request, state.orisId)).toEqual([]);
+  });
+
+  test('member can register to the imported mockup relay race locally', async ({ page, request }) => {
+    if (!state.race) {
+      await loginAs(page, 'registrar');
+      state.race = await ensureOrisRace(page, state.orisId);
+    }
+
+    await loginAs(page, 'member');
+    await page.goto(`./us_race_regon.php?id_zav=${state.race.id}&id_us=${state.memberUser.user_id}`);
+    await expect(page.locator('body')).toContainText(state.race.name);
+
+    await submitMemberRaceRegistration(page, {
+      id_us: String(state.memberUser.user_id),
+      id_zav: String(state.race.id),
+      novy: '1',
+      kat: RELAY_RACE_WORKFLOW.memberCategory,
+      pozn: `member relay note ${state.run.runId}`,
+      pozn2: 'member relay internal',
+    });
+
+    await page.goto(`./us_race_regon.php?id_zav=${state.race.id}&id_us=${state.memberUser.user_id}`);
+    await expect(page.locator('input[name="kat"]')).toHaveValue(RELAY_RACE_WORKFLOW.memberCategory);
+
+    const detail = await getRaceDetail(request, state.race.id);
+    const entry = detail.everyone.find((item) => item.user_id === state.memberUser.user_id);
+
+    expect(entry).toBeTruthy();
+    expect(entry.category).toBe(RELAY_RACE_WORKFLOW.memberCategory);
+    expect(await getOrisApiEventEntries(request, state.orisId)).toEqual([]);
+  });
+
+  test('ORIS API contains no member or participant race entries', async ({ request }) => {
+    expect(await getOrisApiEventEntries(request, state.orisId)).toEqual([]);
+  });
+
+  test('member can unregister from the mockup relay race locally', async ({ page, request }) => {
+    await loginAs(page, 'member');
+    await page.goto(`./us_race_regon.php?id_zav=${state.race.id}&id_us=${state.memberUser.user_id}`);
+    await expect(page.getByRole('button', { name: 'Odhlásit ze závodu' })).toBeVisible();
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await Promise.all([
+      page.waitForURL(/us_race_regoff_exc\.php/),
+      page.getByRole('button', { name: 'Odhlásit ze závodu' }).click(),
+    ]);
+
+    const detail = await getRaceDetail(request, state.race.id);
+    const localEntry = detail.everyone.find((item) => item.user_id === state.memberUser.user_id);
+    expect(localEntry).toBeUndefined();
+    expect(await getOrisApiEventEntries(request, state.orisId)).toEqual([]);
+  });
+
+  test('registrar can move registration dates to past', async ({ page }) => {
+    const oneMonthAgo = new Date();
+    oneMonthAgo.setUTCMonth(oneMonthAgo.getUTCMonth() - 1);
+
+    const oneWeekAgo = new Date();
+    oneWeekAgo.setUTCDate(oneWeekAgo.getUTCDate() - 7);
+
+    const oneDayAgo = new Date();
+    oneDayAgo.setUTCDate(oneDayAgo.getUTCDate() - 1);
+
+    state.expiredEntryDates = {
+      first: formatSavedRaceDate(oneMonthAgo),
+      second: formatSavedRaceDate(oneWeekAgo),
+      third: formatSavedRaceDate(oneDayAgo),
+    };
+
+    await loginAs(page, 'registrar');
+    await updateRace(page, state.race.id, {
+      prihlasky1: state.expiredEntryDates.first,
+      prihlasky2: state.expiredEntryDates.second,
+      prihlasky3: state.expiredEntryDates.third,
+    });
+
+    await page.goto(`./race_edit.php?id=${state.race.id}`);
+    await expect(page.locator('input[name="prihlasky1"]')).toHaveValue(state.expiredEntryDates.first);
+    await expect(page.locator('input[name="prihlasky2"]')).toHaveValue(state.expiredEntryDates.second);
+    await expect(page.locator('input[name="prihlasky3"]')).toHaveValue(state.expiredEntryDates.third);
+  });
+
+  test('member cannot register after the mockup relay race deadline', async ({ page, request }) => {
+    await loginAs(page, 'member');
+    await page.goto('./index.php?id=200&subid=2');
+
+    const raceRow = page.locator('a.adr_name', { hasText: state.race.name }).locator('xpath=ancestor::tr[1]');
+    await expect(raceRow).toBeVisible();
+    await expect(raceRow.getByText('Přihl.', { exact: true })).toHaveCount(0);
+    await expect(raceRow.getByText('Zobrazit', { exact: true })).toBeVisible();
+
+    const detail = await getRaceDetail(request, state.race.id);
+    expect(detail.everyone.find((item) => item.user_id === state.memberUser.user_id)).toBeUndefined();
+    expect(await getOrisApiEventEntries(request, state.orisId)).toEqual([]);
+  });
+
+  test('accountant can create and update a payment for another racer', async ({ page }) => {
+    await loginAs(page, 'accountant');
+
+    const financePopup = await openRaceFinancePopup(page, state.race.id);
+
+    try {
+      const otherRacersForm = financePopup.locator('form', {
+        has: financePopup.locator('h3', { hasText: 'Ostatní závodníci' }),
+      });
+      const firstMemberRow = otherRacersForm.locator('tr', {
+        has: financePopup.locator('a.adr_name'),
+      }).first();
+      const memberName = (await firstMemberRow.locator('td').nth(1).innerText()).trim();
+
+      await firstMemberRow.locator('input[data-col="amount"]').fill('222');
+      await firstMemberRow.locator('input[data-col="note"]').fill('Test nová platba');
+
+      await Promise.all([
+        financePopup.waitForURL(new RegExp(`race_finance_view\\.php\\?race_id=${state.race.id}.*status=ok`)),
+        otherRacersForm.locator('input[type="submit"][value="Vytvořit nové platby"]').click(),
+      ]);
+
+      const createdPayment = financeRow(financePopup, memberName);
+      await expectFinanceRowValues(createdPayment, {
+        amount: '222',
+        note: 'Test nová platba',
+      });
+
+      await createdPayment.amount.fill('234');
+      await createdPayment.note.fill('Test změna platby');
+
+      await Promise.all([
+        financePopup.waitForURL(new RegExp(`race_finance_view\\.php\\?race_id=${state.race.id}.*status=ok`)),
+        financePopup.locator('input[type="submit"][value="Změnit platby"]').click(),
+      ]);
+
+      await expectFinanceRowValues(financeRow(financePopup, memberName), {
+        amount: '234',
+        note: 'Test změna platby',
+      });
+    } finally {
+      await financePopup.close();
+    }
+  });
+});

--- a/version.inc.php
+++ b/version.inc.php
@@ -6,7 +6,7 @@ define('SYSTEM_AUTORS','Arnošt, Kenia a kolektiv autorů');
 
 function GetCodeVersion()
 {
-	return "v3.5.1.673";
+	return "v3.5.1.674";
 }
 
 function GetCopyright()


### PR DESCRIPTION
Opravuje #59.

## Souhrn
- Kontrola relay závodů na typ0='S' detekovala soustředění, ne štafety (chybná záměna v komentáři - S=Soustředění). Podle připomínky @scoufal detekujeme přes příznak 32 (Štafety) v poli `zebricek` na závodě - stejný příznak, který se u závodu nastavuje ručně, žádné volání ORIS API navíc.
- Takové přihlášky sync do ORISu úplně přeskočí; `sync_status` se nemění, aby se případná pozdější oprava příznaku znovu zohlednila bez zásahu do dat (proto beze migrace).
- Sloupec synchronizace v přihláškových formulářích se skryje i pro štafetové závody (stejný příznak, bez API volání).

## Test plan
- [x] `php -l` na upravené soubory
- [x] `npm run test:e2e` v autotest prostředí - 57/60 (2 preexistující selhání nesouvisející s touto změnou, ověřeno i na master)