### PR TITLE
Add local mail catcher (Mailpit) for outgoing email

### DIFF
--- a/Docs/Development.md
+++ b/Docs/Development.md
@@ -31,6 +31,7 @@ Dostupné služby:
 
 * [members](http://127.0.0.1:10100/members)
 * [phpMyAdmin](http://127.0.0.1:10101)
+* [mailpit](http://127.0.0.1:8025)
 
 Bank mock pro vývoj:
 
@@ -89,6 +90,7 @@ Dostupné služby:
 * [phpMyAdmin](http://127.0.0.1:10091)
 * [bank](http://127.0.0.1:10093/__testbench)
 * [ORIS](http://127.0.0.1:10094/__testbench)
+* [mailpit](http://127.0.0.1:10095)
 
 ## Minimální konfigurace
 
@@ -133,6 +135,10 @@ Databáze:
 
 * [phpMyAdmin](http://127.0.0.1:8080)
 * uživatel `root`, heslo `dev4password`
+
+Email:
+
+* [mailpit](http://127.0.0.1:8025)
 
 Práce s kontejnery:
 

--- a/docker-compose.autotest.observe.yml
+++ b/docker-compose.autotest.observe.yml
@@ -12,3 +12,6 @@ services:
       - db   # this line links this container to the db container
     environment:
       PMA_HOST: db
+  mailpit:
+    ports:
+      - "10095:8025"    # web UI + REST API

--- a/docker-compose.autotest.yml
+++ b/docker-compose.autotest.yml
@@ -63,9 +63,7 @@ services:
       - ./docker/db_init/d235220_members_latest.sql:/docker-entrypoint-initdb.d/d235220_members.sql
 
   mailpit:
-    image: axllent/mailpit:latest
-    ports:
-      - "8025:8025"    # web UI + REST API
+    image: axllent/mailpit:v1.30.6
 
 volumes:
   members_node_modules:      #for using node modules from container, not host

--- a/docker-compose.autotest.yml
+++ b/docker-compose.autotest.yml
@@ -8,6 +8,8 @@ services:
     depends_on:
       db:
         condition: service_healthy    # wait until the autotest database import is complete
+      mailpit:
+        condition: service_started
     environment:
       BANK_MOCK_DB_HOST: db
       BANK_MOCK_DB_PORT: 3306
@@ -59,6 +61,11 @@ services:
     volumes:
       # initial database content
       - ./docker/db_init/d235220_members_latest.sql:/docker-entrypoint-initdb.d/d235220_members.sql
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"    # web UI + REST API
 
 volumes:
   members_node_modules:      #for using node modules from container, not host

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,7 @@ services:
       - "10301:10301"    # ORIS mock server
     depends_on:
       - db    #this line links this container to the db container
+      - mailpit
     environment:
       BANK_MOCK_DB_HOST: db
       BANK_MOCK_DB_PORT: 3306
@@ -54,6 +55,10 @@ services:
       - db    #this line links this container to the db container
     environment:
       PMA_HOST: db
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"    # web UI + REST API
 
 
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,7 +56,7 @@ services:
     environment:
       PMA_HOST: db
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.30.6
     ports:
       - "8025:8025"    # web UI + REST API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./:/var/www/html/members    # mount the repository; Apache exposes only the www runtime
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.30.6
     ports:
       - "8025:8025"    # web UI + REST API
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,14 @@ services:
     depends_on:
       db:    #this line links this container to the db container
         condition: service_healthy    # wait until the autotest database import is complete
+      mailpit:
+        condition: service_started
     volumes:
       - ./:/var/www/html/members    # mount the repository; Apache exposes only the www runtime
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "8025:8025"    # web UI + REST API
   db:
     image: mariadb:10.11
     environment:

--- a/docker/Dockerfile.srv
+++ b/docker/Dockerfile.srv
@@ -20,6 +20,28 @@ Alias /members /var/www/html/members/www\n\
     > /etc/apache2/conf-available/members.conf \
     && a2enconf members
 
+# Relay PHP's mail() to the local mailpit catcher instead of a real MTA.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends msmtp ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo '\
+defaults\n\
+auth off\n\
+tls off\n\
+logfile /var/www/html/members/www/logs/msmtp.log\n\
+\n\
+account mailpit\n\
+host mailpit\n\
+port 1025\n\
+\n\
+account default : mailpit' \
+    > /etc/msmtprc \
+    && chmod 644 /etc/msmtprc
+
+RUN echo 'sendmail_path = "/usr/bin/msmtp -t -i"' \
+    > /usr/local/etc/php/conf.d/mail.ini
+
 EXPOSE 10100
 
 FROM base AS autotest

--- a/docker/Dockerfile.srv
+++ b/docker/Dockerfile.srv
@@ -26,6 +26,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN echo "defaults" > /etc/msmtprc && \
+    echo "# local mail catcher only - never point this at a real relay" >> /etc/msmtprc && \
     echo "auth off" >> /etc/msmtprc && \
     echo "tls off" >> /etc/msmtprc && \
     echo "logfile /var/www/html/members/logs/msmtp.log" >> /etc/msmtprc && \

--- a/docker/Dockerfile.srv
+++ b/docker/Dockerfile.srv
@@ -29,7 +29,7 @@ RUN echo "defaults" > /etc/msmtprc && \
     echo "# local mail catcher only - never point this at a real relay" >> /etc/msmtprc && \
     echo "auth off" >> /etc/msmtprc && \
     echo "tls off" >> /etc/msmtprc && \
-    echo "logfile /var/www/html/members/logs/msmtp.log" >> /etc/msmtprc && \
+    echo "logfile /var/www/html/members/www/logs/msmtp.log" >> /etc/msmtprc && \
     echo "" >> /etc/msmtprc && \
     echo "account mailpit" >> /etc/msmtprc && \
     echo "host mailpit" >> /etc/msmtprc && \

--- a/docker/Dockerfile.srv
+++ b/docker/Dockerfile.srv
@@ -25,20 +25,19 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends msmtp ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo '\
-defaults\n\
-auth off\n\
-tls off\n\
-logfile /var/www/html/members/logs/msmtp.log\n\
-\n\
-account mailpit\n\
-host mailpit\n\
-port 1025\n\
-\n\
-account default : mailpit' \
-    > /etc/msmtprc \
-    && chown www-data:www-data /etc/msmtprc \
-    && chmod 600 /etc/msmtprc
+RUN echo "defaults" > /etc/msmtprc && \
+    echo "auth off" >> /etc/msmtprc && \
+    echo "tls off" >> /etc/msmtprc && \
+    echo "logfile /var/www/html/members/logs/msmtp.log" >> /etc/msmtprc && \
+    echo "" >> /etc/msmtprc && \
+    echo "account mailpit" >> /etc/msmtprc && \
+    echo "host mailpit" >> /etc/msmtprc && \
+    echo "port 1025" >> /etc/msmtprc && \
+    echo "from noreply@members.local" >> /etc/msmtprc && \
+    echo "" >> /etc/msmtprc && \
+    echo "account default : mailpit" >> /etc/msmtprc && \
+    chown www-data:www-data /etc/msmtprc && \
+    chmod 600 /etc/msmtprc
 
 RUN echo 'sendmail_path = "/usr/bin/msmtp -t -i"' \
     > /usr/local/etc/php/conf.d/mail.ini

--- a/docker/Dockerfile.srv
+++ b/docker/Dockerfile.srv
@@ -29,7 +29,7 @@ RUN echo '\
 defaults\n\
 auth off\n\
 tls off\n\
-logfile /var/www/html/members/www/logs/msmtp.log\n\
+logfile /var/www/html/members/logs/msmtp.log\n\
 \n\
 account mailpit\n\
 host mailpit\n\
@@ -37,7 +37,8 @@ port 1025\n\
 \n\
 account default : mailpit' \
     > /etc/msmtprc \
-    && chmod 644 /etc/msmtprc
+    && chown www-data:www-data /etc/msmtprc \
+    && chmod 600 /etc/msmtprc
 
 RUN echo 'sendmail_path = "/usr/bin/msmtp -t -i"' \
     > /usr/local/etc/php/conf.d/mail.ini

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -37,6 +37,8 @@ These files are not part of the PHP runtime and must not be deployed to the prod
 - `PLAYWRIGHT_BASE_URL` overrides the application URL. Default: `http://web:10100/members/`
 - `MEMBERS_E2E_SUITE=no-oris` disables all ORIS configuration for application requests and makes mock `/API` return HTTP 503
 - `MEMBERS_E2E_SUITE=no-oris-key` leaves ORIS enabled but omits `$g_oris_club_key` for application requests
+- `MAILPIT_URL` overrides the Mailpit API base URL used by `tests/playwright/helpers/mail.js`. Default: `http://mailpit:8025`
+- Captured outgoing email can be inspected/asserted on via `tests/playwright/helpers/mail.js` (`clearMailbox`, `waitForEmailTo`)
 - The reusable login helper lives in `tests/playwright/components/login.js`
 - Shared auth constants live in `tests/playwright/constants/auth.js`
   - `DEFAULT_PASSWORD` = `54321`

--- a/tests/playwright/helpers/mail.js
+++ b/tests/playwright/helpers/mail.js
@@ -1,0 +1,66 @@
+const MAILPIT_BASE_URL = process.env.MAILPIT_URL || 'http://mailpit:8025';
+
+async function clearMailbox(request) {
+  const response = await request.delete(`${MAILPIT_BASE_URL}/api/v1/messages`);
+
+  if (!response.ok()) {
+    throw new Error(`Failed to clear mailpit mailbox: HTTP ${response.status()}`);
+  }
+}
+
+async function findMessageSummary(request, recipient, subject) {
+  const response = await request.get(`${MAILPIT_BASE_URL}/api/v1/messages`);
+
+  if (!response.ok()) {
+    throw new Error(`Failed to list mailpit messages: HTTP ${response.status()}`);
+  }
+
+  const { messages } = await response.json();
+
+  return messages.find((message) => {
+    const matchesRecipient = message.To.some((addr) => addr.Address === recipient);
+    const matchesSubject = subject === undefined || message.Subject === subject;
+    return matchesRecipient && matchesSubject;
+  });
+}
+
+async function fetchFullMessage(request, id) {
+  const response = await request.get(`${MAILPIT_BASE_URL}/api/v1/message/${id}`);
+
+  if (!response.ok()) {
+    throw new Error(`Failed to load mailpit message ${id}: HTTP ${response.status()}`);
+  }
+
+  const message = await response.json();
+
+  return {
+    subject: message.Subject,
+    text: message.Text,
+    html: message.HTML,
+    to: message.To,
+    from: message.From,
+  };
+}
+
+async function waitForEmailTo(request, recipient, { subject, timeoutMs = 5000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const summary = await findMessageSummary(request, recipient, subject);
+
+    if (summary) {
+      return fetchFullMessage(request, summary.ID);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `No email to '${recipient}'${subject ? ` with subject '${subject}'` : ''} arrived within ${timeoutMs}ms`,
+  );
+}
+
+module.exports = {
+  clearMailbox,
+  waitForEmailTo,
+};

--- a/tests/playwright/helpers/mail.js
+++ b/tests/playwright/helpers/mail.js
@@ -1,5 +1,11 @@
 const MAILPIT_BASE_URL = process.env.MAILPIT_URL || 'http://mailpit:8025';
 
+// clearMailbox() issues a global DELETE against the shared Mailpit instance, wiping every
+// captured message regardless of which spec or worker created it. Playwright runs specs with
+// fullyParallel: true, so multiple workers can hit Mailpit concurrently. This is safe today
+// because only one spec asserts on email, but it will become a source of flakiness as soon as a
+// second email-asserting spec runs at the same time. Prefer waitForEmailTo(request, recipient, ...)
+// with a unique-per-test recipient address for isolation instead of relying on clearMailbox().
 async function clearMailbox(request) {
   const response = await request.delete(`${MAILPIT_BASE_URL}/api/v1/messages`);
 
@@ -18,7 +24,7 @@ async function findMessageSummary(request, recipient, subject) {
   const { messages } = await response.json();
 
   return messages.find((message) => {
-    const matchesRecipient = message.To.some((addr) => addr.Address === recipient);
+    const matchesRecipient = (message.To || []).some((addr) => addr.Address === recipient);
     const matchesSubject = subject === undefined || message.Subject === subject;
     return matchesRecipient && matchesSubject;
   });

--- a/tests/playwright/mail-catcher.spec.js
+++ b/tests/playwright/mail-catcher.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+const { execSync } = require('child_process');
+const { clearMailbox, waitForEmailTo } = require('./helpers/mail');
+
+test('captures an email sent via PHP mail() through msmtp into mailpit', async ({ request }) => {
+  await clearMailbox(request);
+
+  const recipient = 'mail-catcher-smoke@example.test';
+  const subject = `Mailpit smoke test ${Date.now()}`;
+  const body = 'This message proves the mail catcher pipeline works end-to-end.';
+
+  execSync(
+    `php -r 'if (!mail(${JSON.stringify(recipient)}, ${JSON.stringify(subject)}, ${JSON.stringify(body)})) { exit(1); }'`,
+    { cwd: '/var/www/html/members' },
+  );
+
+  const message = await waitForEmailTo(request, recipient, { subject });
+
+  expect(message.subject).toBe(subject);
+  expect(message.text.trim()).toBe(body);
+  expect(message.to.some((addr) => addr.Address === recipient)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Adds a local Mailpit-based mail catcher so outgoing email (sent via PHP's native `mail()`) can be inspected in a browser and asserted on in Playwright, instead of silently disappearing (no container previously had an MTA).
- `msmtp` is installed in the shared `base` Dockerfile stage and relays `mail()` calls, unauthenticated/no-TLS, to a new `mailpit` service — identical wiring added to all three compose stacks (`docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.autotest.yml`), with `docker-compose.autotest.yml` keeping its existing zero-published-host-ports convention (mailpit's UI is only exposed via `docker-compose.autotest.observe.yml`, on port 10095).
- `tests/playwright/helpers/mail.js` (`clearMailbox`, `waitForEmailTo`) plus `tests/playwright/mail-catcher.spec.js` prove the pipeline end-to-end.
- Zero application PHP code changed. `axllent/mailpit` is pinned to `v1.30.6` (not `:latest`) since the helper binds to its REST API shape.
- Documented in `Docs/Development.md` and `tests/playwright/README.md`.

## Test plan
- [x] Full `npm run test:e2e` run against this branch: 56 passed, 3 failed, 4 did not run
- [x] Same 3 failures (identical test names) confirmed present on the pre-change base commit too — pre-existing, unrelated to this change (finance/race UI assertions, no overlap with touched files)
- [x] Manual smoke test (`mail()` → msmtp → mailpit) verified end-to-end on all three stacks
- [x] Verified dev + autotest stacks can run concurrently without port conflicts (the autotest zero-ports convention this PR had to preserve)