### PR TITLE
Fix  handle "Stafety", "Druzstva" and "Sprintove stafety" as relay

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -15,7 +15,7 @@ const regularTestIgnore = [
 ];
 const alternateTestIgnore = [
   ...regularTestIgnore,
-  '**/workflows/oris-*.spec.js',
+  '**/oris-*.spec.js',
 ];
 const testIgnore = alternateOrisSuite ? alternateTestIgnore : regularTestIgnore;
 

--- a/tests/playwright/helpers/oris-mock.js
+++ b/tests/playwright/helpers/oris-mock.js
@@ -145,6 +145,7 @@ async function createOrisApiEntry(request, overrides = {}) {
     form: {
       method: 'createEntry',
       format: 'json',
+      clubkey: 'mockClubKey',
       ...overrides,
     },
   });

--- a/www/connectors.php
+++ b/www/connectors.php
@@ -116,9 +116,9 @@ class OrisCZConnector implements ConnectorInterface {
 		];
 		$zebricek = $map[$levelId] ?? 0x0080; // Default to 0x80 if not found
 
-		// Sprint relays and teams are relay events too, even though their ORIS level
+		// Relays, sprint relays and teams are relay events, even though their ORIS level
 		// can be MCR rather than CPS (for example ORIS events 9285 and 9289).
-		if (in_array((int)$disciplineId, [6, 15], true)) {
+		if (in_array((int)$disciplineId, [5, 6, 15], true)) {
 			$zebricek |= 32;
 		}
 

--- a/www/connectors.php
+++ b/www/connectors.php
@@ -104,7 +104,7 @@ class OrisCZConnector implements ConnectorInterface {
 		return OrisIntegrationServiceFactory::getConfiguredBaseUrl() . 'Zavod?id=' . $raceId;
 	}
 
-	private function mapLevelToZebricek2($levelId) {
+	private function mapLevelToZebricek2($levelId, $disciplineId = null) {
 		$map = [
 			1  => 17, // MCR
 			3  => 6,  // ZB
@@ -114,7 +114,15 @@ class OrisCZConnector implements ConnectorInterface {
 			11 => 24,  // OM
 			17 => 17   // VET
 		];
-		return $map[$levelId] ?? 0x0080; // Default to 0x80 if not found
+		$zebricek = $map[$levelId] ?? 0x0080; // Default to 0x80 if not found
+
+		// Sprint relays and teams are relay events too, even though their ORIS level
+		// can be MCR rather than CPS (for example ORIS events 9285 and 9289).
+		if (in_array((int)$disciplineId, [6, 15], true)) {
+			$zebricek |= 32;
+		}
+
+		return $zebricek;
 	}
 
 	private function mapSport($sportId) {
@@ -186,7 +194,10 @@ class OrisCZConnector implements ConnectorInterface {
 				'oblasti' => $oblasti,
 				'typ0' => 'Z',
 				'typ' => $this->mapSport($raceData['Sport']['ID']),
-				'zebricek2' => $this->mapLevelToZebricek2($raceData['Level']['ID']),
+				'zebricek2' => $this->mapLevelToZebricek2(
+					$raceData['Level']['ID'],
+					$raceData['Discipline']['ID'] ?? null
+				),
 				'ranking' => $raceData['Ranking'],
 				'odkaz' => $this->getRaceURL($raceData['ID']),
 				'prihlasky' => strtotime($raceData['EntryDate1']),


### PR DESCRIPTION
 Všechny závody s disciplínou Stafety(5), Sprintové štafety(6) a Družstva(15) jsou vedeny jako štafetový žebříček a členové nejsou automaticky přihlašováni do Orisu