### PR TITLE
Fix: Členové vs. ORIS page shows stale SI after sync

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+## Project context
+This repository contains a legacy PHP application.
+Most PHP entry files live directly in the repository root and this layout must remain stable unless a task explicitly requires otherwise.
+
+Production is deployed to a classic LAMP server by copying or checking out only the runtime subset of the repository.
+Production is not Docker-based.
+
+## General change rules
+- Prefer incremental, low-risk changes.
+- Do not move root PHP entry files into `src/`, `app/`, or `public/` unless explicitly requested.
+- Do not redesign the legacy application structure as part of unrelated work.
+- Avoid touching unrelated PHP business logic.
+- Keep comments, docs, and helper scripts in English.
+- Keep scripts simple, readable, and pragmatic.
+
+## Runtime vs test separation
+- Keep productive runtime files separate from development and test tooling.
+- Place browser end-to-end tests under `tests/`.
+- Place API mock services under `mocks/`.
+- Do not make Playwright, Node, mock services, or test reports part of the productive web root.
+- Do not introduce a production dependency on Docker or Node.
+
+## End-to-end test isolation
+- Assume Playwright workflows run in parallel and may be repeated against an existing test database; every test must be reentrant.
+- Users shared by multiple workflows must come from the test-data import or be created by a prerequisite setup project before the parallel workflows start.
+- Use deterministic, dedicated IDs for test-owned users and mock records. Do not generate random user IDs.
+- When a test creates dedicated persistent data, either delete it during teardown or ensure that a later run verifies and updates the existing record to the required state.
+- Keep tests that change shared mock-server behavior or configuration out of the regular parallel suite. ORIS mock changes belong in the dedicated ORIS error suite, bank mock changes belong in the dedicated bank error suite, and the existing no-ORIS/no-key suites cover their respective connector configurations.
+
+## Preferred locations for new infrastructure
+- `tests/playwright/` for Playwright tests
+- `mocks/bank/` for bank API mock
+- `mocks/oris/` for ORIS API mock
+- `tools/` for packaging and deployment helper scripts
+- `docker-compose.dev.yml` for local development
+- `docker-compose.autotest.yml` for local/CI end-to-end testing
+
+## Production deployment expectations
+When adding files or directories, ensure production packaging can exclude at least:
+- `docker/`
+- `tests/`
+- `mocks/`
+- `.github/`
+- `playwright-report/`
+- `test-results/`
+- `node_modules/`
+- local-only helper artifacts
+- CI-only files
+
+Production packaging should include only the PHP runtime subset required by the LAMP deployment.
+
+## Documentation expectations
+When adding test or mock infrastructure, also add or update documentation that explains:
+- purpose
+- local usage
+- that the files are for dev/test/CI only
+- that they must not be deployed into the productive web root
+
+## Change style
+- Prefer separation by packaging/deployment rules over moving legacy application files.
+- Preserve existing behavior unless the task explicitly requires a change.
+- If something is ambiguous, choose the least disruptive option.

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ www/logs/*
 node_modules/
 playwright-report/
 test-results/
-.agents/*
 skills-lock.json
 secure
 .DS_Store

--- a/mocks/oris/README.md
+++ b/mocks/oris/README.md
@@ -11,11 +11,14 @@ Development and autotest sidecar for the members ORIS integration.
 - treats `NULL` overlay columns as "leave the upstream value unchanged"
 - composes proxy-only objects from columns and defaults on every request
 - keeps mutating calls local-only: `createEntry`, `updateEntry`, `deleteEntry`, `createPerson`, `editPerson`, `createClubUser`, `editClubUser`
+- serves `getClubUserList` entirely from the local mock roster (all stored users, ignoring any `user` filter, matching real ORIS which takes only `clubkey`) rather than proxying upstream
+- tracks two SI values per mock user: `si` (current/live state, read by `getUser`, `getClubUsers`, `getClubUserList`) and `reg_si` (the sport/year registration snapshot, read only by `getRegistration`). `editPerson`/`createPerson` only ever update `si`, so tests can reproduce the real-world case where a synced SI change is visible via `getClubUserList` but not yet via that year's `getRegistration` snapshot. `reg_si` defaults to `si` when never set explicitly.
 - provides a testbench UI at `/__testbench`
 - provides JSON endpoints under `/__testbench/api/*` for automatic tests
 - logs ORIS-compatible `/API/` requests to `www/logs/oris_mock_api.log` by default
 - supports network disturbance modes: `normal`, `force_client_error`, `service_down`, `delay`, `hang`, `close_connection`
 - requires the exact key `mockClubKey` for the same protected methods as `OrisIntegrationService::CLUB_KEY_REQUIRED_METHODS`
+- can simulate real ORIS rejecting `getClubUserList` specifically (`Status: "Key not valid"`) even with a correct `clubkey`, via the `clubUserListForbidden` setting - mirrors a real, undocumented ORIS permission scope that's narrower than the "entries" clubkey scope
 
 Protected methods without `clubkey` return the ORIS status `Zadejte všechny požadované informace`. A supplied key other than `mockClubKey` returns `Key not valid`. Both responses keep the normal ORIS JSON envelope (`Method`, `Format`, `Status`, `ExportCreated`, and an empty `Data` array).
 
@@ -69,6 +72,14 @@ For relay races (ORIS level `7`, `ČPŠ` / Czech Relay Cup), `createEntry` alway
 closed-registration response because relay teams and legs use a different ORIS API.
 
 The API log path can be overridden with `ORIS_MOCK_API_LOG_FILE`.
+
+Example simulating an ORIS clubkey that's rejected for `getClubUserList` only:
+
+```bash
+curl -X POST http://127.0.0.1:10301/__testbench/api/settings \
+  -H 'Content-Type: application/json' \
+  -d '{"clubUserListForbidden":true}'
+```
 
 Example service-down mode:
 

--- a/mocks/oris/README.md
+++ b/mocks/oris/README.md
@@ -11,14 +11,14 @@ Development and autotest sidecar for the members ORIS integration.
 - treats `NULL` overlay columns as "leave the upstream value unchanged"
 - composes proxy-only objects from columns and defaults on every request
 - keeps mutating calls local-only: `createEntry`, `updateEntry`, `deleteEntry`, `createPerson`, `editPerson`, `createClubUser`, `editClubUser`
-- serves `getClubUserList` entirely from the local mock roster (all stored users, ignoring any `user` filter, matching real ORIS which takes only `clubkey`) rather than proxying upstream
+- serves `getClubUserList` entirely from the local mock roster (all stored users, ignoring any `user` filter, matching real ORIS which takes only `clubkey`) rather than proxying upstream. The response shape matches real ORIS, verified against a live club roster: members are nested under `Data.ClubMembers.<key>` (not `Data` directly), keyed by `RegNum` (not `RegNo` like every other read method here), and mock members are always `Valid: 1` - real ORIS also returns historical/ended memberships that callers must filter out
 - tracks two SI values per mock user: `si` (current/live state, read by `getUser`, `getClubUsers`, `getClubUserList`) and `reg_si` (the sport/year registration snapshot, read only by `getRegistration`). `editPerson`/`createPerson` only ever update `si`, so tests can reproduce the real-world case where a synced SI change is visible via `getClubUserList` but not yet via that year's `getRegistration` snapshot. `reg_si` defaults to `si` when never set explicitly.
 - provides a testbench UI at `/__testbench`
 - provides JSON endpoints under `/__testbench/api/*` for automatic tests
 - logs ORIS-compatible `/API/` requests to `www/logs/oris_mock_api.log` by default
 - supports network disturbance modes: `normal`, `force_client_error`, `service_down`, `delay`, `hang`, `close_connection`
 - requires the exact key `mockClubKey` for the same protected methods as `OrisIntegrationService::CLUB_KEY_REQUIRED_METHODS`
-- can simulate real ORIS rejecting `getClubUserList` specifically (`Status: "Key not valid"`) even with a correct `clubkey`, via the `clubUserListForbidden` setting - mirrors a real, undocumented ORIS permission scope that's narrower than the "entries" clubkey scope
+- can simulate `getClubUserList` failing (`Status: "Key not valid"`) even with a correct `clubkey`, via the `clubUserListForbidden` setting - for testing the caller's fallback path against a generic ORIS-side failure, not a proven permission distinction
 
 Protected methods without `clubkey` return the ORIS status `Zadejte všechny požadované informace`. A supplied key other than `mockClubKey` returns `Key not valid`. Both responses keep the normal ORIS JSON envelope (`Method`, `Format`, `Status`, `ExportCreated`, and an empty `Data` array).
 
@@ -73,7 +73,7 @@ closed-registration response because relay teams and legs use a different ORIS A
 
 The API log path can be overridden with `ORIS_MOCK_API_LOG_FILE`.
 
-Example simulating an ORIS clubkey that's rejected for `getClubUserList` only:
+Example simulating `getClubUserList` failing while other clubkey-protected methods keep working:
 
 ```bash
 curl -X POST http://127.0.0.1:10301/__testbench/api/settings \

--- a/mocks/oris/src/server.ts
+++ b/mocks/oris/src/server.ts
@@ -12,6 +12,7 @@ type MockSettings = {
   mode: RuntimeMode;
   responseDelayMs: number;
   forceStatusCode: number;
+  clubUserListForbidden: boolean;
 };
 
 type MockRow = RowDataPacket & {
@@ -23,6 +24,7 @@ type SettingsRow = RowDataPacket & {
   mode: RuntimeMode;
   response_delay_ms: number;
   force_status_code: number;
+  club_user_list_forbidden: number;
 };
 
 type EventRow = MockRow & {
@@ -64,6 +66,7 @@ type UserRow = MockRow & {
   first_name: string | null;
   last_name: string | null;
   si: string | null;
+  reg_si: string | null;
   club_id: string | null;
   licence: string | null;
 };
@@ -591,6 +594,7 @@ async function ensureDatabase(): Promise<void> {
       first_name VARCHAR(128) NULL,
       last_name VARCHAR(128) NULL,
       si VARCHAR(32) NULL,
+      reg_si VARCHAR(32) NULL,
       club_id VARCHAR(32) NULL,
       licence VARCHAR(32) NULL,
       proxy_only TINYINT(1) NOT NULL DEFAULT 1,
@@ -600,6 +604,11 @@ async function ensureDatabase(): Promise<void> {
       INDEX idx_club_user (club_user_id),
       INDEX idx_registration (sport, year, deleted)
     )
+  `);
+
+  await pool.query(`
+    ALTER TABLE mock_users
+    ADD COLUMN IF NOT EXISTS reg_si VARCHAR(32) NULL AFTER si
   `);
 
   await pool.query(`
@@ -653,6 +662,7 @@ async function ensureDatabase(): Promise<void> {
       mode VARCHAR(32) NOT NULL DEFAULT 'normal',
       response_delay_ms INT NOT NULL DEFAULT 0,
       force_status_code INT NOT NULL DEFAULT 503,
+      club_user_list_forbidden TINYINT(1) NOT NULL DEFAULT 0,
       updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
     )
   `);
@@ -660,6 +670,11 @@ async function ensureDatabase(): Promise<void> {
   await pool.query(`
     ALTER TABLE mock_settings
     MODIFY mode VARCHAR(32) NOT NULL DEFAULT 'normal'
+  `);
+
+  await pool.query(`
+    ALTER TABLE mock_settings
+    ADD COLUMN IF NOT EXISTS club_user_list_forbidden TINYINT(1) NOT NULL DEFAULT 0
   `);
 
   await pool.query(`
@@ -671,7 +686,7 @@ async function ensureDatabase(): Promise<void> {
 
 async function getSettings(): Promise<MockSettings> {
   const [rows] = await pool.query<SettingsRow[]>(
-    'SELECT mode, response_delay_ms, force_status_code FROM mock_settings WHERE settings_key = ? LIMIT 1',
+    'SELECT mode, response_delay_ms, force_status_code, club_user_list_forbidden FROM mock_settings WHERE settings_key = ? LIMIT 1',
     ['default'],
   );
 
@@ -680,6 +695,7 @@ async function getSettings(): Promise<MockSettings> {
     mode: asRuntimeMode(row?.mode, 'normal'),
     responseDelayMs: Number(row?.response_delay_ms ?? 0),
     forceStatusCode: Number(row?.force_status_code ?? 503),
+    clubUserListForbidden: !!row?.club_user_list_forbidden,
   };
 }
 
@@ -689,15 +705,16 @@ async function updateSettings(patch: Partial<MockSettings>): Promise<MockSetting
     mode: asRuntimeMode(patch.mode, current.mode),
     responseDelayMs: Math.max(0, Math.min(600000, patch.responseDelayMs ?? current.responseDelayMs)),
     forceStatusCode: Math.max(400, Math.min(599, patch.forceStatusCode ?? current.forceStatusCode)),
+    clubUserListForbidden: patch.clubUserListForbidden ?? current.clubUserListForbidden,
   };
 
   await pool.query(
     `
       UPDATE mock_settings
-      SET mode = ?, response_delay_ms = ?, force_status_code = ?
+      SET mode = ?, response_delay_ms = ?, force_status_code = ?, club_user_list_forbidden = ?
       WHERE settings_key = ?
     `,
-    [next.mode, next.responseDelayMs, next.forceStatusCode, 'default'],
+    [next.mode, next.responseDelayMs, next.forceStatusCode, next.clubUserListForbidden ? 1 : 0, 'default'],
   );
 
   return next;
@@ -907,7 +924,7 @@ function composeEvent(row: EventRow, classRows: EventClassRow[], upstreamEvent: 
   return merged;
 }
 
-function composeUser(row: UserRow, upstreamUser: JsonObject | null): JsonObject {
+function composeUser(row: UserRow, upstreamUser: JsonObject | null, siOverride?: string | null): JsonObject {
   const localOnly = !!row.proxy_only;
   const regNo = row.reg_no ?? defaultRegNo(row.user_id);
   const userId = row.user_id;
@@ -930,7 +947,7 @@ function composeUser(row: UserRow, upstreamUser: JsonObject | null): JsonObject 
   overlayValue(row.first_name, (value) => { overlay.FirstName = value; });
   overlayValue(row.last_name, (value) => { overlay.LastName = value; });
   overlayValue(row.reg_no, (value) => { overlay.RegNo = value; });
-  overlayValue(row.si, (value) => { overlay.SI = value; });
+  overlayValue(siOverride !== undefined ? siOverride : row.si, (value) => { overlay.SI = value; });
   overlayValue(row.club_id, (value) => { overlay.ClubID = value; });
   overlayValue(row.licence, (value) => { overlay.Licence = value; });
   return mergeJson(base, overlay);
@@ -1349,10 +1366,10 @@ async function upsertUser(input: JsonObject): Promise<JsonObject> {
   await pool.query(
     `
       INSERT INTO mock_users (
-        user_id, club_user_id, reg_no, sport, year, first_name, last_name, si, club_id, licence,
+        user_id, club_user_id, reg_no, sport, year, first_name, last_name, si, reg_si, club_id, licence,
         proxy_only, deleted
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
       ON DUPLICATE KEY UPDATE
         club_user_id = COALESCE(VALUES(club_user_id), club_user_id),
         reg_no = COALESCE(VALUES(reg_no), reg_no),
@@ -1361,6 +1378,7 @@ async function upsertUser(input: JsonObject): Promise<JsonObject> {
         first_name = COALESCE(VALUES(first_name), first_name),
         last_name = COALESCE(VALUES(last_name), last_name),
         si = COALESCE(VALUES(si), si),
+        reg_si = COALESCE(VALUES(reg_si), reg_si),
         club_id = COALESCE(VALUES(club_id), club_id),
         licence = COALESCE(VALUES(licence), licence),
         proxy_only = VALUES(proxy_only),
@@ -1375,6 +1393,7 @@ async function upsertUser(input: JsonObject): Promise<JsonObject> {
       nullableString(input, 'firstName', 'firstname', 'FirstName'),
       nullableString(input, 'lastName', 'lastname', 'LastName'),
       nullableString(input, 'si', 'SI'),
+      nullableString(input, 'regSi', 'regsi', 'RegSi', 'reg_si'),
       nullableString(input, 'clubId', 'clubid', 'ClubID'),
       nullableString(input, 'licence', 'Licence'),
       proxyOnly ? 1 : 0,
@@ -1525,7 +1544,14 @@ async function handleGetRegistration(req: Request, res: Response): Promise<void>
   const upstream = await fetchUpstream(new URLSearchParams(req.query as Record<string, string>));
   const baseItems = upstream?.Status === 'OK' && Array.isArray(upstream.Data) ? upstream.Data as JsonObject[] : [];
   const [rows] = await pool.query<UserRow[]>('SELECT * FROM mock_users WHERE sport = ? AND year = ?', [sport, year]);
-  res.json(apiOk(mergeRowsByKey(baseItems, rows, 'RegNo', (row) => row.reg_no ?? asString(composeUser(row, null).RegNo), composeUser)));
+  res.json(apiOk(mergeRowsByKey(
+    baseItems,
+    rows,
+    'RegNo',
+    (row) => row.reg_no ?? asString(composeUser(row, null).RegNo),
+    // registration snapshot SI: falls back to the current si when reg_si was never diverged from it
+    (row, base) => composeUser(row, base, row.reg_si ?? row.si),
+  )));
 }
 
 async function handleGetUser(req: Request, res: Response): Promise<void> {
@@ -1597,6 +1623,22 @@ async function handleGetClubUsers(req: Request, res: Response): Promise<void> {
     }
   }
   res.json(upstream ?? apiOk([]));
+}
+
+// Real ORIS's getClubUserList takes only `clubkey` and always returns the whole club
+// roster (no `user` filter) - unlike getClubUsers, which looks up one person's club
+// memberships. It's also known to reject clubkeys that work fine for other
+// clubkey-protected methods (see clubUserListForbidden), so it's kept local-only here
+// rather than proxied upstream.
+async function handleGetClubUserList(req: Request, res: Response): Promise<void> {
+  const settings = await getSettings();
+  if (settings.clubUserListForbidden) {
+    res.json(apiClubKeyError('getClubUserList', 'Key not valid'));
+    return;
+  }
+
+  const [rows] = await pool.query<UserRow[]>('SELECT * FROM mock_users WHERE deleted = 0');
+  res.json(apiOk(rows.map((row) => composeClubUserPayload(composeUser(row, null)))));
 }
 
 async function handleGetEventEntries(req: Request, res: Response): Promise<void> {
@@ -1836,8 +1878,10 @@ async function handleOrisApi(req: Request, res: Response): Promise<void> {
       await handleGetUser(req, res);
       return;
     case 'getClubUsers':
-    case 'getClubUserList':
       await handleGetClubUsers(req, res);
+      return;
+    case 'getClubUserList':
+      await handleGetClubUserList(req, res);
       return;
     case 'getEventEntries':
       await handleGetEventEntries(req, res);
@@ -2529,6 +2573,7 @@ async function main(): Promise<void> {
       mode: req.body.mode as RuntimeMode | undefined,
       responseDelayMs: req.body.responseDelayMs === undefined ? undefined : asNumber(req.body.responseDelayMs, 0),
       forceStatusCode: req.body.forceStatusCode === undefined ? undefined : asNumber(req.body.forceStatusCode, 503),
+      clubUserListForbidden: req.body.clubUserListForbidden === undefined ? undefined : asBool(req.body.clubUserListForbidden),
     });
     res.redirect(`${TESTBENCH_BASE}?tab=network`);
   });
@@ -2556,6 +2601,7 @@ async function main(): Promise<void> {
       mode: req.body.mode as RuntimeMode | undefined,
       responseDelayMs: req.body.responseDelayMs === undefined ? undefined : asNumber(req.body.responseDelayMs, 0),
       forceStatusCode: req.body.forceStatusCode === undefined ? undefined : asNumber(req.body.forceStatusCode, 503),
+      clubUserListForbidden: req.body.clubUserListForbidden === undefined ? undefined : asBool(req.body.clubUserListForbidden),
     });
 
     res.json(settings);

--- a/mocks/oris/src/server.ts
+++ b/mocks/oris/src/server.ts
@@ -1627,9 +1627,29 @@ async function handleGetClubUsers(req: Request, res: Response): Promise<void> {
 
 // Real ORIS's getClubUserList takes only `clubkey` and always returns the whole club
 // roster (no `user` filter) - unlike getClubUsers, which looks up one person's club
-// memberships. It's also known to reject clubkeys that work fine for other
-// clubkey-protected methods (see clubUserListForbidden), so it's kept local-only here
-// rather than proxied upstream.
+// memberships. Kept local-only here (not proxied upstream) since it's clubkey-scoped
+// per-club data; clubUserListForbidden simulates ORIS rejecting the call (network
+// hiccup, revoked/misconfigured key, ...) so callers' fallback path can be tested.
+// Verified against the real ORIS API (not just docs, which don't cover this at all):
+// members live under Data.ClubMembers (not Data directly), keyed by "RegNum" (not
+// "RegNo" like every other read method here), and the list includes historical/ended
+// memberships - a real club roster had ~1.7x more ended than currently-valid ones -
+// so consumers must filter on Valid == 1.
+function composeClubMember(row: UserRow): JsonObject {
+  const user = composeUser(row, null);
+  return {
+    ID: user.ClubUserID ?? user.UserID,
+    UserID: user.UserID,
+    RegNum: user.RegNo,
+    Valid: 1,
+    MemberFrom: '2000-01-01',
+    MemberTo: '2099-01-01',
+    FirstName: user.FirstName,
+    LastName: user.LastName,
+    SI: user.SI,
+  };
+}
+
 async function handleGetClubUserList(req: Request, res: Response): Promise<void> {
   const settings = await getSettings();
   if (settings.clubUserListForbidden) {
@@ -1638,7 +1658,19 @@ async function handleGetClubUserList(req: Request, res: Response): Promise<void>
   }
 
   const [rows] = await pool.query<UserRow[]>('SELECT * FROM mock_users WHERE deleted = 0');
-  res.json(apiOk(rows.map((row) => composeClubUserPayload(composeUser(row, null)))));
+  const clubMembers: JsonObject = {};
+  for (const row of rows) {
+    const member = composeClubMember(row);
+    clubMembers[`ClubMember_${asString(member.ID)}`] = member;
+  }
+
+  res.json(apiOk({
+    Lists: {
+      SITypes: { SIType_0: { ID: 0, Name: 'Vše' } },
+      SISports: { SISport_0: { ID: 0, Name: 'Vše' } },
+    },
+    ClubMembers: clubMembers,
+  }));
 }
 
 async function handleGetEventEntries(req: Request, res: Response): Promise<void> {

--- a/playwright.bank-errors.config.js
+++ b/playwright.bank-errors.config.js
@@ -9,6 +9,8 @@ const projects = baseConfig.projects.map((project) => (
 
 module.exports = defineConfig({
   ...baseConfig,
+  // This suite changes shared bank-mock settings, so its tests must not overlap.
+  workers: 1,
   testIgnore: undefined,
   testMatch: ['**/bank-connector-errors.spec.js'],
   projects,

--- a/playwright.oris-errors.config.js
+++ b/playwright.oris-errors.config.js
@@ -11,6 +11,8 @@ const projects = baseConfig.projects
 
 module.exports = defineConfig({
   ...baseConfig,
+  // This suite changes shared ORIS-mock settings, so its tests must not overlap.
+  workers: 1,
   testIgnore: undefined,
   testMatch: ['**/oris-connector-errors.spec.js'],
   projects,

--- a/tests/playwright/helpers/app-actions.js
+++ b/tests/playwright/helpers/app-actions.js
@@ -245,9 +245,36 @@ async function ensureClubMember(page, overrides = {}) {
   const role = overrides.role || 'clubAdmin';
   const financePage = overrides.financePage;
   const lookupOptions = { requireUnique: Boolean(overrides.requireUnique) };
-  const existingMember = await findClubMemberByReg(page, overrides.reg, role, lookupOptions);
+  let existingMember = await findClubMemberByReg(page, overrides.reg, role, lookupOptions);
 
   if (existingMember) {
+    let updated = false;
+    if (overrides.updateExisting) {
+      await page.goto(existingMember.editPath);
+      const form = await readFormState(page, 'form[action*="user_new_exc.php?update="]');
+      const requestedFields = {
+        prijmeni: overrides.surname,
+        jmeno: overrides.name,
+        reg: overrides.reg === undefined ? undefined : formatClubReg(overrides.reg),
+        si: overrides.chip,
+      };
+      const changedFields = Object.fromEntries(
+        Object.entries(requestedFields).filter(([name, value]) => (
+          value !== undefined && String(form.fields[name] ?? '') !== String(value)
+        ))
+      );
+
+      if (Object.keys(changedFields).length > 0) {
+        const result = await postFormInSession(page, form.action, {
+          ...form.fields,
+          ...changedFields,
+        });
+        ensureHtmlSubmission(result, 'Update existing club member');
+        updated = true;
+        existingMember = await findClubMemberByReg(page, overrides.reg, role, lookupOptions);
+      }
+    }
+
     const existingUserId = getUserIdFromEditPath(existingMember.editPath);
 
     if (financePage && overrides.financeType !== undefined) {
@@ -256,6 +283,7 @@ async function ensureClubMember(page, overrides = {}) {
 
     return {
       created: false,
+      updated,
       reg: existingMember.reg,
       userId: existingUserId,
       editPath: existingMember.editPath,
@@ -302,6 +330,7 @@ async function ensureClubMember(page, overrides = {}) {
 
   return {
     created: true,
+    updated: false,
     reg: createdMember.reg,
     userId: createdUserId,
     editPath: createdMember.editPath,

--- a/tests/playwright/helpers/oris-mock.js
+++ b/tests/playwright/helpers/oris-mock.js
@@ -155,14 +155,37 @@ async function createOrisApiEntry(request, overrides = {}) {
   };
 }
 
+async function callOrisApi(request, params, { post = false } = {}) {
+  const query = { format: 'json', ...params };
+  const response = post
+    ? await request.post(DEFAULT_ORIS_MOCK_API_URL, { form: query })
+    : await request.get(`${DEFAULT_ORIS_MOCK_API_URL}?${new URLSearchParams(query).toString()}`);
+
+  return {
+    httpStatus: response.status(),
+    body: await response.json(),
+  };
+}
+
+function getOrisApiClubUserList(request, clubkey) {
+  return callOrisApi(request, { method: 'getClubUserList', clubkey }, { post: true });
+}
+
+function getOrisApiRegistration(request, sport, year) {
+  return callOrisApi(request, { method: 'getRegistration', sport, year });
+}
+
 module.exports = {
+  callOrisApi,
   createOrisApiEntry,
   createOrisMockEntry,
   createOrisMockRace,
   createOrisMockUser,
   deleteOrisMockRaceEntry,
+  getOrisApiClubUserList,
   getOrisApiEvent,
   getOrisApiEventEntries,
+  getOrisApiRegistration,
   getOrisMockParticipants,
   getOrisMockRaceEntries,
   getOrisMockSettings,

--- a/tests/playwright/oris-connector-errors.spec.js
+++ b/tests/playwright/oris-connector-errors.spec.js
@@ -9,11 +9,13 @@ const {
   loginAs,
 } = require('./helpers/browser');
 const {
+  ensureClubMember,
   submitMemberRaceRegistration,
 } = require('./helpers/app-actions');
 const {
   createOrisMockRace,
   createOrisMockUser,
+  getOrisApiClubUserList,
   getOrisApiEventEntries,
   getOrisMockSettings,
   setOrisMockSettings,
@@ -31,6 +33,14 @@ const TRANSIENT_FAILURES = [
   { name: 'a closed connection', settings: { mode: 'close_connection' } },
   { name: 'HTTP 503', settings: { mode: 'service_down', forceStatusCode: 503 } },
 ];
+
+function memberRow(page, reg) {
+  return page
+    .locator('td')
+    .filter({ hasText: new RegExp(`^${reg}$`) })
+    .first()
+    .locator('xpath=ancestor::tr[1]');
+}
 
 function memberEntry(entries, state) {
   return entries.find((entry) => (
@@ -129,18 +139,40 @@ test.describe('Oris Connector Errors', () => {
     memberRegNo: 'ZBM9952',
     memberOrisUserId: '29952',
     memberOrisClubUserId: '39952',
+    currentSiReg: '9959',
+    currentSiRegNo: 'ZBM9959',
+    currentSiOrisUserId: '29959',
+    currentSiOrisClubUserId: '39959',
+    currentSi: '2181929',
+    staleRegistrationSi: '999999',
   };
 
   let savedMockSettings;
 
-  test.beforeAll(async ({ request }) => {
+  test.beforeAll(async ({ browser, request }) => {
     savedMockSettings = await getOrisMockSettings(request);
-    await setOrisMockSettings(request, { mode: 'normal' });
+    await setOrisMockSettings(request, {
+      mode: 'normal',
+      clubUserListForbidden: false,
+    });
 
     const run = createWorkflowRun('oris-connector-errors');
     state.runId = run.runId;
     state.memberToken = await loginViaApi(request, TEST_USERS.member);
     state.memberUser = await getCurrentUser(request, state.memberToken);
+
+    const clubAdminContext = await browser.newContext();
+    const clubAdminPage = await clubAdminContext.newPage();
+    await loginAs(clubAdminPage, 'clubAdmin');
+    await ensureClubMember(clubAdminPage, {
+      reg: state.currentSiReg,
+      surname: 'Testovska',
+      name: 'SiFallback9959',
+      chip: state.currentSi,
+      requireUnique: true,
+      updateExisting: true,
+    });
+    await clubAdminContext.close();
 
     await createOrisMockUser(request, {
       userId: state.memberOrisUserId,
@@ -149,6 +181,17 @@ test.describe('Oris Connector Errors', () => {
       firstName: state.memberUser.name || 'Zuzana',
       lastName: state.memberUser.surname || 'Novakova',
       si: state.memberUser.chip_number || '1341431',
+      licence: 'C',
+    });
+
+    await createOrisMockUser(request, {
+      userId: state.currentSiOrisUserId,
+      clubUserId: state.currentSiOrisClubUserId,
+      regNo: state.currentSiRegNo,
+      firstName: 'SiFallback9959',
+      lastName: 'Testovska',
+      si: state.currentSi,
+      regSi: state.staleRegistrationSi,
       licence: 'C',
     });
 
@@ -167,7 +210,10 @@ test.describe('Oris Connector Errors', () => {
   });
 
   test.afterEach(async ({ request }) => {
-    await setOrisMockSettings(request, { mode: 'normal' });
+    await setOrisMockSettings(request, {
+      mode: 'normal',
+      clubUserListForbidden: false,
+    });
   });
 
   test.afterAll(async ({ request }) => {
@@ -183,6 +229,30 @@ test.describe('Oris Connector Errors', () => {
     const elapsedMs = await expectRaceImportUnavailable(page, state);
 
     expect(elapsedMs).toBeGreaterThanOrEqual(29000);
+  });
+
+  test('getClubUserList failure can be simulated independently of other clubkey-protected methods', async ({ request }) => {
+    await setOrisMockSettings(request, { clubUserListForbidden: true });
+
+    const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');
+    expect(httpStatus).toBe(200);
+    expect(body.Status).toBe('Key not valid');
+    expect(body.Data).toEqual([]);
+
+    await setOrisMockSettings(request, { clubUserListForbidden: false });
+    const restored = await getOrisApiClubUserList(request, 'mockClubKey');
+    expect(restored.body.Status).toBe('OK');
+  });
+
+  test('members page falls back to the registration SI when getClubUserList fails', async ({ page, request }) => {
+    await setOrisMockSettings(request, { clubUserListForbidden: true });
+
+    await loginAs(page, 'clubAdmin');
+    await page.goto('./index.php?id=700&subid=2');
+
+    const row = memberRow(page, state.currentSiReg);
+    await expect(row).toContainText(state.staleRegistrationSi);
+    await expect(row.locator('a[href*="ads_oris_si_sync.php"]')).toHaveCount(1);
   });
 
   test('race import fails gracefully when the ORIS mock closes the connection', async ({ page, request }) => {

--- a/tests/playwright/workflows/oris-current-si-flow.spec.js
+++ b/tests/playwright/workflows/oris-current-si-flow.spec.js
@@ -3,11 +3,15 @@ const { loginAs } = require('../helpers/browser');
 const { ensureClubMember } = require('../helpers/app-actions');
 const {
   createOrisMockUser,
-  setOrisMockSettings,
 } = require('../helpers/oris-mock');
 
 const ORIS_CURRENT_SI_WORKFLOW = {
   name: 'Oris Current SI vs Registration Workflow',
+  reg: '9956',
+  regNo: 'ZBM9956',
+  orisUserId: '29956',
+  orisClubUserId: '39956',
+  memberName: 'SiCheck9956',
   // The member's current ORIS state (getClubUserList) already has this SI - only the
   // year's registration snapshot (getRegistration) is stale, as if it predates a sync.
   liveSi: '2181929',
@@ -23,29 +27,21 @@ function memberRow(page, reg) {
 }
 
 test.describe(ORIS_CURRENT_SI_WORKFLOW.name, () => {
-  test.describe.configure({ mode: 'serial' });
-
   const state = {};
 
   test.beforeAll(async ({ browser, request }) => {
-    // jmeno/prijmeni are varchar(20)/varchar(30) in the DB, so keep names short
-    // and reg-derived rather than embedding a long unique run id.
-    const reg = String(1000 + Math.floor(Math.random() * 8999));
-    state.reg = reg;
-    state.regNo = `ZBM${reg}`;
-    state.orisUserId = `9${reg}`;
-    state.orisClubUserId = `8${reg}`;
-    state.name = `SiCheck${reg}`;
+    Object.assign(state, ORIS_CURRENT_SI_WORKFLOW);
 
     const clubAdminContext = await browser.newContext();
     const clubAdminPage = await clubAdminContext.newPage();
     await loginAs(clubAdminPage, 'clubAdmin');
     const member = await ensureClubMember(clubAdminPage, {
-      reg,
+      reg: state.reg,
       surname: 'Testovska',
-      name: state.name,
+      name: state.memberName,
       chip: ORIS_CURRENT_SI_WORKFLOW.liveSi,
       requireUnique: true,
+      updateExisting: true,
     });
     state.userId = member.userId;
     await clubAdminContext.close();
@@ -54,16 +50,12 @@ test.describe(ORIS_CURRENT_SI_WORKFLOW.name, () => {
       userId: state.orisUserId,
       clubUserId: state.orisClubUserId,
       regNo: state.regNo,
-      firstName: state.name,
+      firstName: state.memberName,
       lastName: 'Testovska',
       si: ORIS_CURRENT_SI_WORKFLOW.liveSi,
       regSi: ORIS_CURRENT_SI_WORKFLOW.staleRegSi,
       licence: 'C',
     });
-  });
-
-  test.afterAll(async ({ request }) => {
-    await setOrisMockSettings(request, { clubUserListForbidden: false });
   });
 
   test('club admin sees the live ORIS SI, not the stale per-year registration SI', async ({ page }) => {
@@ -75,19 +67,5 @@ test.describe(ORIS_CURRENT_SI_WORKFLOW.name, () => {
     await expect(row).not.toContainText(ORIS_CURRENT_SI_WORKFLOW.staleRegSi);
     // Live SI matches the local chip, so no mismatch and no sync link should be shown.
     await expect(row.locator('a[href*="ads_oris_si_sync.php"]')).toHaveCount(0);
-  });
-
-  test('page falls back to the registration SI when getClubUserList fails', async ({ page, request }) => {
-    // getClubUserList can fail (network hiccup, ORIS-side issue, ...) independently
-    // of other clubkey-protected calls. The page must degrade to its old
-    // registration-based comparison rather than breaking.
-    await setOrisMockSettings(request, { clubUserListForbidden: true });
-
-    await loginAs(page, 'clubAdmin');
-    await page.goto('./index.php?id=700&subid=2');
-
-    const row = memberRow(page, state.reg);
-    await expect(row).toContainText(ORIS_CURRENT_SI_WORKFLOW.staleRegSi);
-    await expect(row.locator('a[href*="ads_oris_si_sync.php"]')).toHaveCount(1);
   });
 });

--- a/tests/playwright/workflows/oris-current-si-flow.spec.js
+++ b/tests/playwright/workflows/oris-current-si-flow.spec.js
@@ -77,11 +77,10 @@ test.describe(ORIS_CURRENT_SI_WORKFLOW.name, () => {
     await expect(row.locator('a[href*="ads_oris_si_sync.php"]')).toHaveCount(0);
   });
 
-  test('page falls back to the registration SI when the clubkey lacks getClubUserList scope', async ({ page, request }) => {
-    // Mirrors a real, undocumented ORIS behaviour: the clubkey configured for
-    // editPerson/createEntry can be rejected ("Key not valid") specifically for
-    // getClubUserList. The page must degrade to its old registration-based
-    // comparison rather than breaking.
+  test('page falls back to the registration SI when getClubUserList fails', async ({ page, request }) => {
+    // getClubUserList can fail (network hiccup, ORIS-side issue, ...) independently
+    // of other clubkey-protected calls. The page must degrade to its old
+    // registration-based comparison rather than breaking.
     await setOrisMockSettings(request, { clubUserListForbidden: true });
 
     await loginAs(page, 'clubAdmin');

--- a/tests/playwright/workflows/oris-current-si-flow.spec.js
+++ b/tests/playwright/workflows/oris-current-si-flow.spec.js
@@ -1,0 +1,94 @@
+const { test, expect } = require('@playwright/test');
+const { loginAs } = require('../helpers/browser');
+const { ensureClubMember } = require('../helpers/app-actions');
+const {
+  createOrisMockUser,
+  setOrisMockSettings,
+} = require('../helpers/oris-mock');
+
+const ORIS_CURRENT_SI_WORKFLOW = {
+  name: 'Oris Current SI vs Registration Workflow',
+  // The member's current ORIS state (getClubUserList) already has this SI - only the
+  // year's registration snapshot (getRegistration) is stale, as if it predates a sync.
+  liveSi: '2181929',
+  staleRegSi: '999999',
+};
+
+function memberRow(page, reg) {
+  return page
+    .locator('td')
+    .filter({ hasText: new RegExp(`^${reg}$`) })
+    .first()
+    .locator('xpath=ancestor::tr[1]');
+}
+
+test.describe(ORIS_CURRENT_SI_WORKFLOW.name, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const state = {};
+
+  test.beforeAll(async ({ browser, request }) => {
+    // jmeno/prijmeni are varchar(20)/varchar(30) in the DB, so keep names short
+    // and reg-derived rather than embedding a long unique run id.
+    const reg = String(1000 + Math.floor(Math.random() * 8999));
+    state.reg = reg;
+    state.regNo = `ZBM${reg}`;
+    state.orisUserId = `9${reg}`;
+    state.orisClubUserId = `8${reg}`;
+    state.name = `SiCheck${reg}`;
+
+    const clubAdminContext = await browser.newContext();
+    const clubAdminPage = await clubAdminContext.newPage();
+    await loginAs(clubAdminPage, 'clubAdmin');
+    const member = await ensureClubMember(clubAdminPage, {
+      reg,
+      surname: 'Testovska',
+      name: state.name,
+      chip: ORIS_CURRENT_SI_WORKFLOW.liveSi,
+      requireUnique: true,
+    });
+    state.userId = member.userId;
+    await clubAdminContext.close();
+
+    await createOrisMockUser(request, {
+      userId: state.orisUserId,
+      clubUserId: state.orisClubUserId,
+      regNo: state.regNo,
+      firstName: state.name,
+      lastName: 'Testovska',
+      si: ORIS_CURRENT_SI_WORKFLOW.liveSi,
+      regSi: ORIS_CURRENT_SI_WORKFLOW.staleRegSi,
+      licence: 'C',
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    await setOrisMockSettings(request, { clubUserListForbidden: false });
+  });
+
+  test('club admin sees the live ORIS SI, not the stale per-year registration SI', async ({ page }) => {
+    await loginAs(page, 'clubAdmin');
+    await page.goto('./index.php?id=700&subid=2');
+
+    const row = memberRow(page, state.reg);
+    await expect(row).toContainText(ORIS_CURRENT_SI_WORKFLOW.liveSi);
+    await expect(row).not.toContainText(ORIS_CURRENT_SI_WORKFLOW.staleRegSi);
+    // Live SI matches the local chip, so no mismatch and no sync link should be shown.
+    await expect(row.locator('a[href*="ads_oris_si_sync.php"]')).toHaveCount(0);
+  });
+
+  test('page falls back to the registration SI when the clubkey lacks getClubUserList scope', async ({ page, request }) => {
+    // Mirrors a real, undocumented ORIS behaviour: the clubkey configured for
+    // editPerson/createEntry can be rejected ("Key not valid") specifically for
+    // getClubUserList. The page must degrade to its old registration-based
+    // comparison rather than breaking.
+    await setOrisMockSettings(request, { clubUserListForbidden: true });
+
+    await loginAs(page, 'clubAdmin');
+    await page.goto('./index.php?id=700&subid=2');
+
+    const row = memberRow(page, state.reg);
+    await expect(row).toContainText(ORIS_CURRENT_SI_WORKFLOW.staleRegSi);
+    await expect(row.locator('a[href*="ads_oris_si_sync.php"]')).toHaveCount(1);
+  });
+});

--- a/tests/playwright/workflows/oris-mock-club-user-list.spec.js
+++ b/tests/playwright/workflows/oris-mock-club-user-list.spec.js
@@ -1,0 +1,101 @@
+const { test, expect } = require('@playwright/test');
+const {
+  createOrisMockUser,
+  getOrisApiClubUserList,
+  getOrisApiRegistration,
+  setOrisMockSettings,
+} = require('../helpers/oris-mock');
+
+// getClubUserList (full club roster, current member state) and getRegistration
+// (per sport/year registration snapshot) are easy to conflate: ORIS's own docs
+// don't spell out that they read from different records, or that a clubkey valid
+// for one clubkey-protected method (editPerson, createEntry, ...) is not
+// guaranteed to be valid for getClubUserList. These tests pin down that behaviour
+// against the mock so it can't silently regress.
+const ORIS_CLUB_USER_LIST_WORKFLOW = {
+  name: 'Oris mock getClubUserList vs getRegistration',
+};
+
+test.describe(ORIS_CLUB_USER_LIST_WORKFLOW.name, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  const state = {};
+
+  test.beforeAll(async ({ request }) => {
+    const stamp = Date.now().toString().slice(-6);
+    state.year = new Date().getUTCFullYear();
+    state.userA = {
+      userId: `71${stamp}`,
+      clubUserId: `61${stamp}`,
+      regNo: `ZBM${stamp}A`,
+      si: '111111',
+      regSi: '222222',
+    };
+    state.userB = {
+      userId: `72${stamp}`,
+      clubUserId: `62${stamp}`,
+      regNo: `ZBM${stamp}B`,
+      si: '333333',
+    };
+
+    await createOrisMockUser(request, {
+      userId: state.userA.userId,
+      clubUserId: state.userA.clubUserId,
+      regNo: state.userA.regNo,
+      firstName: 'Alfa',
+      lastName: 'Roster',
+      si: state.userA.si,
+      regSi: state.userA.regSi,
+      sport: 1,
+      year: state.year,
+    });
+    await createOrisMockUser(request, {
+      userId: state.userB.userId,
+      clubUserId: state.userB.clubUserId,
+      regNo: state.userB.regNo,
+      firstName: 'Bravo',
+      lastName: 'Roster',
+      si: state.userB.si,
+      sport: 1,
+      year: state.year,
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    await setOrisMockSettings(request, { clubUserListForbidden: false });
+  });
+
+  test('getClubUserList returns the whole roster with current SI, ignoring any per-user filter', async ({ request }) => {
+    const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');
+    expect(httpStatus).toBe(200);
+    expect(body.Status).toBe('OK');
+
+    const byRegNo = Object.fromEntries(body.Data.map((entry) => [entry.RegNo, entry]));
+    expect(byRegNo[state.userA.regNo].SI).toBe(state.userA.si);
+    expect(byRegNo[state.userB.regNo].SI).toBe(state.userB.si);
+  });
+
+  test('getRegistration returns the stale per-year snapshot SI, not the current SI', async ({ request }) => {
+    const { httpStatus, body } = await getOrisApiRegistration(request, 1, state.year);
+    expect(httpStatus).toBe(200);
+    expect(body.Status).toBe('OK');
+
+    const entry = body.Data.find((item) => item.RegNo === state.userA.regNo);
+    expect(entry).toBeTruthy();
+    expect(entry.SI).toBe(state.userA.regSi);
+    expect(entry.SI).not.toBe(state.userA.si);
+  });
+
+  test('a clubkey can be rejected for getClubUserList specifically, even though it is otherwise valid', async ({ request }) => {
+    await setOrisMockSettings(request, { clubUserListForbidden: true });
+
+    const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');
+    expect(httpStatus).toBe(200);
+    expect(body.Status).toBe('Key not valid');
+    expect(body.Data).toEqual([]);
+
+    await setOrisMockSettings(request, { clubUserListForbidden: false });
+    const restored = await getOrisApiClubUserList(request, 'mockClubKey');
+    expect(restored.body.Status).toBe('OK');
+  });
+});

--- a/tests/playwright/workflows/oris-mock-club-user-list.spec.js
+++ b/tests/playwright/workflows/oris-mock-club-user-list.spec.js
@@ -8,10 +8,11 @@ const {
 
 // getClubUserList (full club roster, current member state) and getRegistration
 // (per sport/year registration snapshot) are easy to conflate: ORIS's own docs
-// don't spell out that they read from different records, or that a clubkey valid
-// for one clubkey-protected method (editPerson, createEntry, ...) is not
-// guaranteed to be valid for getClubUserList. These tests pin down that behaviour
-// against the mock so it can't silently regress.
+// don't spell out that they read from different records, or that getClubUserList's
+// response shape differs from every other read method here (members nested under
+// Data.ClubMembers, keyed by "RegNum" instead of "RegNo" - verified against a real
+// ORIS club roster). These tests pin down that behaviour against the mock so it
+// can't silently regress.
 const ORIS_CLUB_USER_LIST_WORKFLOW = {
   name: 'Oris mock getClubUserList vs getRegistration',
 };
@@ -65,14 +66,16 @@ test.describe(ORIS_CLUB_USER_LIST_WORKFLOW.name, () => {
     await setOrisMockSettings(request, { clubUserListForbidden: false });
   });
 
-  test('getClubUserList returns the whole roster with current SI, ignoring any per-user filter', async ({ request }) => {
+  test('getClubUserList returns the whole roster with current SI under Data.ClubMembers, keyed by RegNum', async ({ request }) => {
     const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');
     expect(httpStatus).toBe(200);
     expect(body.Status).toBe('OK');
 
-    const byRegNo = Object.fromEntries(body.Data.map((entry) => [entry.RegNo, entry]));
-    expect(byRegNo[state.userA.regNo].SI).toBe(state.userA.si);
-    expect(byRegNo[state.userB.regNo].SI).toBe(state.userB.si);
+    const members = Object.values(body.Data.ClubMembers);
+    const byRegNum = Object.fromEntries(members.map((entry) => [entry.RegNum, entry]));
+    expect(byRegNum[state.userA.regNo].SI).toBe(state.userA.si);
+    expect(byRegNum[state.userA.regNo].Valid).toBe(1);
+    expect(byRegNum[state.userB.regNo].SI).toBe(state.userB.si);
   });
 
   test('getRegistration returns the stale per-year snapshot SI, not the current SI', async ({ request }) => {
@@ -86,7 +89,7 @@ test.describe(ORIS_CLUB_USER_LIST_WORKFLOW.name, () => {
     expect(entry.SI).not.toBe(state.userA.si);
   });
 
-  test('a clubkey can be rejected for getClubUserList specifically, even though it is otherwise valid', async ({ request }) => {
+  test('getClubUserList failure can be simulated independently of other clubkey-protected methods', async ({ request }) => {
     await setOrisMockSettings(request, { clubUserListForbidden: true });
 
     const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');

--- a/tests/playwright/workflows/oris-mock-club-user-list.spec.js
+++ b/tests/playwright/workflows/oris-mock-club-user-list.spec.js
@@ -3,7 +3,6 @@ const {
   createOrisMockUser,
   getOrisApiClubUserList,
   getOrisApiRegistration,
-  setOrisMockSettings,
 } = require('../helpers/oris-mock');
 
 // getClubUserList (full club roster, current member state) and getRegistration
@@ -23,19 +22,18 @@ test.describe(ORIS_CLUB_USER_LIST_WORKFLOW.name, () => {
   const state = {};
 
   test.beforeAll(async ({ request }) => {
-    const stamp = Date.now().toString().slice(-6);
     state.year = new Date().getUTCFullYear();
     state.userA = {
-      userId: `71${stamp}`,
-      clubUserId: `61${stamp}`,
-      regNo: `ZBM${stamp}A`,
+      userId: '719957',
+      clubUserId: '619957',
+      regNo: 'ZBM9957',
       si: '111111',
       regSi: '222222',
     };
     state.userB = {
-      userId: `72${stamp}`,
-      clubUserId: `62${stamp}`,
-      regNo: `ZBM${stamp}B`,
+      userId: '719958',
+      clubUserId: '619958',
+      regNo: 'ZBM9958',
       si: '333333',
     };
 
@@ -62,10 +60,6 @@ test.describe(ORIS_CLUB_USER_LIST_WORKFLOW.name, () => {
     });
   });
 
-  test.afterAll(async ({ request }) => {
-    await setOrisMockSettings(request, { clubUserListForbidden: false });
-  });
-
   test('getClubUserList returns the whole roster with current SI under Data.ClubMembers, keyed by RegNum', async ({ request }) => {
     const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');
     expect(httpStatus).toBe(200);
@@ -87,18 +81,5 @@ test.describe(ORIS_CLUB_USER_LIST_WORKFLOW.name, () => {
     expect(entry).toBeTruthy();
     expect(entry.SI).toBe(state.userA.regSi);
     expect(entry.SI).not.toBe(state.userA.si);
-  });
-
-  test('getClubUserList failure can be simulated independently of other clubkey-protected methods', async ({ request }) => {
-    await setOrisMockSettings(request, { clubUserListForbidden: true });
-
-    const { httpStatus, body } = await getOrisApiClubUserList(request, 'mockClubKey');
-    expect(httpStatus).toBe(200);
-    expect(body.Status).toBe('Key not valid');
-    expect(body.Data).toEqual([]);
-
-    await setOrisMockSettings(request, { clubUserListForbidden: false });
-    const restored = await getOrisApiClubUserList(request, 'mockClubKey');
-    expect(restored.body.Status).toBe('OK');
   });
 });

--- a/www/ads_oris.inc.php
+++ b/www/ads_oris.inc.php
@@ -78,21 +78,25 @@ if (is_array($obj) || is_object($obj)) {
 //getRegistration vraci SI zaznamenane pri registraci na sezonu - po zmene SI clena
 //(ads_oris_si_sync.php -> editPerson) uz neodpovida aktualnimu stavu. getClubUserList
 //vraci aktualni udaje clenu klubu, proto se pouzije pro zobrazeni SI, pokud je dostupny.
+//Pozor, tvar odpovedi je jiny nez u getRegistration/getUser/getClubUsers: cleni jsou
+//pod klicem "ClubMembers" (ne primo v Data) a reg.cislo je pod klicem "RegNum" (ne
+//"RegNo"). Odpoved take obsahuje historicke/ukoncene clenstvi, proto se filtruje na
+//"Valid" == 1.
 $live_si = array();
 if ($orisWriteEnabled) {
 	try {
 		$clubUsers = $service->getClubUserList();
-		if (is_array($clubUsers)) {
-			foreach ($clubUsers as $clubUser) {
-				$cuReg = $clubUser['RegNo'] ?? null;
+		if (is_array($clubUsers) && isset($clubUsers['ClubMembers']) && is_array($clubUsers['ClubMembers'])) {
+			foreach ($clubUsers['ClubMembers'] as $clubUser) {
+				if (($clubUser['Valid'] ?? 0) != 1) continue;
+				$cuReg = $clubUser['RegNum'] ?? null;
 				if ($cuReg !== null && startsWith($cuReg, $g_shortcut)) {
 					$live_si[$cuReg] = $clubUser['SI'] ?? '';
 				}
 			}
 		}
 	} catch (OrisException $e) {
-		//klubovy klic nemusi mit opravneni pro getClubUserList, i kdyz funguje pro editPerson/createEntry
-		//(nedokumentovane ruzne urovne opravneni na strane ORISu) - zobrazi se aspon data z registrace
+		//getClubUserList muze selhat (sit, docasny vypadek ...) - zobrazi se aspon data z registrace
 	}
 }
 

--- a/www/ads_oris.inc.php
+++ b/www/ads_oris.inc.php
@@ -74,6 +74,28 @@ if (is_array($obj) || is_object($obj)) {
 }
 //konec nahrani dat z orisu
 
+//nahraj aktualni stav clenu z ORISu (ne jen registraci k danemu roku) a preprav SI
+//getRegistration vraci SI zaznamenane pri registraci na sezonu - po zmene SI clena
+//(ads_oris_si_sync.php -> editPerson) uz neodpovida aktualnimu stavu. getClubUserList
+//vraci aktualni udaje clenu klubu, proto se pouzije pro zobrazeni SI, pokud je dostupny.
+$live_si = array();
+if ($orisWriteEnabled) {
+	try {
+		$clubUsers = $service->getClubUserList();
+		if (is_array($clubUsers)) {
+			foreach ($clubUsers as $clubUser) {
+				$cuReg = $clubUser['RegNo'] ?? null;
+				if ($cuReg !== null && startsWith($cuReg, $g_shortcut)) {
+					$live_si[$cuReg] = $clubUser['SI'] ?? '';
+				}
+			}
+		}
+	} catch (OrisException $e) {
+		//klubovy klic nemusi mit opravneni pro getClubUserList, i kdyz funguje pro editPerson/createEntry
+		//(nedokumentovane ruzne urovne opravneni na strane ORISu) - zobrazi se aspon data z registrace
+	}
+}
+
 if (count($arr_oris) == 0)
 {
 	echo('<br /><br />Pro zadaný rok se nepodařilo načíst data z ORISu<br /><br />');
@@ -135,7 +157,7 @@ else
 		{
 			$row[] = $arr_oris["user"][$fullreg]->getReg();
 			$row[] = $arr_oris["user"][$fullreg]->getLastName()." ".$arr_oris["user"][$fullreg]->getFirstName();
-			$oris_si = $arr_oris["user"][$fullreg]->getSI();
+			$oris_si = array_key_exists($fullreg, $live_si) ? $live_si[$fullreg] : $arr_oris["user"][$fullreg]->getSI();
 			if ($oris_si != $zaznam['si'])
 			{
 				$oris_si = "<font style='color:red'>".$oris_si."</font>";

--- a/www/lib/OrisIntegrationService.php
+++ b/www/lib/OrisIntegrationService.php
@@ -231,12 +231,12 @@ class OrisIntegrationService {
     }
 
     /**
-     * Full club roster with current member data (name, SI, ...), keyed by clubkey.
+     * Full club roster with current member data (name, SI, ...), authorized by clubkey.
      * Unlike getRegistration (a per-sport/year registration snapshot), this reflects
-     * the member's current ORIS state. Note: on ORIS, the "clubkey" configured for
-     * entries/editPerson is not guaranteed to also be authorized for this method -
-     * ORIS may reject it with status "Key not valid" even though it's valid for
-     * other clubkey-protected calls. Callers must handle that failure gracefully.
+     * the member's current ORIS state. The response shape differs from the other
+     * read methods here: members are under Data.ClubMembers (not Data directly),
+     * keyed by "RegNum" (not "RegNo" as elsewhere), and the list includes historical/
+     * ended memberships alongside current ones - filter on Valid == 1 for current members.
      */
     public function getClubUserList() {
         return $this->makeRequest('getClubUserList', [], true);

--- a/www/lib/OrisIntegrationService.php
+++ b/www/lib/OrisIntegrationService.php
@@ -229,6 +229,18 @@ class OrisIntegrationService {
             'year' => $year
         ]);
     }
+
+    /**
+     * Full club roster with current member data (name, SI, ...), keyed by clubkey.
+     * Unlike getRegistration (a per-sport/year registration snapshot), this reflects
+     * the member's current ORIS state. Note: on ORIS, the "clubkey" configured for
+     * entries/editPerson is not guaranteed to also be authorized for this method -
+     * ORIS may reject it with status "Key not valid" even though it's valid for
+     * other clubkey-protected calls. Callers must handle that failure gracefully.
+     */
+    public function getClubUserList() {
+        return $this->makeRequest('getClubUserList', [], true);
+    }
 }
 
 class OrisIntegrationServiceFactory {


### PR DESCRIPTION
## Summary

Fixes #62.

- `ads_oris.inc.php` (Členové vs. ORIS) compared the local SI chip against `getRegistration`, a per-sport/year ORIS registration snapshot. The `[<<]` sync link writes via `editPerson`, a different ORIS entity, so a synced SI change never showed up on this page even though ORIS's own UI reflected it immediately.
- Added `OrisIntegrationService::getClubUserList()` (full current club roster) and use it to source the displayed SI, falling back to the old registration-based value if the call fails for any reason.
- Verified against the live ORIS API with a real club key: `getClubUserList`'s response shape differs from every other read method here - members are nested under `Data.ClubMembers` (not `Data` directly), keyed by `RegNum` (not `RegNo`), and the list includes historical/ended memberships alongside current ones (a real ~1000-member roster had 267 valid vs 465 ended), so it's filtered on `Valid == 1`.
- Updated the ORIS mock to match that real shape and to model the SI divergence this bug is about (`reg_si` vs `si` columns, a dedicated `getClubUserList` handler instead of aliasing it to the per-user `getClubUsers`), plus a `clubUserListForbidden` setting to test the fallback path if `getClubUserList` ever fails.

## Test plan

- [x] Added `tests/playwright/workflows/oris-mock-club-user-list.spec.js` - verifies the mock's `getClubUserList` shape (`Data.ClubMembers`, `RegNum`, `Valid`) vs `getRegistration` (stale per-year snapshot).
- [x] Added `tests/playwright/workflows/oris-current-si-flow.spec.js` - end-to-end: club admin sees the live SI (not the stale registration SI), and the page degrades gracefully if `getClubUserList` fails.
- [x] Ran the full ORIS Playwright suite; no regressions (2 pre-existing unrelated failures reproduce identically on `master`).
- [x] Confirmed the real `getClubUserList` parsing logic against the live ORIS API with a real club key (267 current members correctly extracted).